### PR TITLE
Check fee paid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hex",
+ "rand",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hex = "0.4.3"
 uuid = { version = "1.10.0", features = ["v4", "macro-diagnostics"] }
 sqlx = { version = "0.8.0", features = [ "runtime-tokio", "sqlite" ] }
 async-trait = "0.1.81"
+rand = "0.8.5"
 # Conflicts with tokio-rusqlite
 # ("failed to select a version for `libsqlite3-sys` which could resolve this conflict")
 #matrix-sdk = "0.7.1"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,8 +2,7 @@
 
 use crate::chain;
 use crate::chain::{Account, AccountId, AccountSet};
-
-use uuid::Uuid;
+use rand::{distributions::Alphanumeric, Rng};
 
 #[derive(Debug, Clone)]
 pub struct Person {
@@ -28,7 +27,7 @@ pub type Secret = String;
 
 pub async fn handle_chain_event(event: chain::Event) -> anyhow::Result<()> {
     match event {
-        chain::Event::JudgementRequested(who,  id) => {
+        chain::Event::JudgementRequested(who, id) => {
             let person = Person {
                 id: who,
                 display_name: id.display_name,
@@ -49,5 +48,12 @@ fn generate_challenges(accounts: AccountSet) -> Vec<Challenge> {
 }
 
 fn generate_secret(_account: &Account) -> Secret {
-    Uuid::new_v4().to_string()
+    // Generate a random alphanumeric string of 8 characters
+    let secret: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect();
+
+    secret
 }


### PR DESCRIPTION
The account should have a FeePaid judgement from the registrar in identityOf if the JudgementRequested event was successful. 
If our event listener misses events, we can always check the identityOf storage for the account. 
If our registrar index is present with a FeePaid status, we know the judgement request was made and the fee was paid, allowing us to proceed with providing second challenges.

im not sure tho if this is the correct location to proceed with the check tho.