### PR TITLE
Handle BC events and extend to other API endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,6 +7450,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber 0.3.19",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio-tungstenite = "0.24.0"
 futures-util = "0.3.31"
 subxt-signer = "0.38.0"
 redis = { version = "0.27.6", features = ["aio", "json", "log", "tokio-comp", "uuid"] }
+url = "2"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,11 +4,11 @@ registrar_index = 0
 keystore_path = "./keyfile"
 
 [websocket]
-ip = [127,0,0,1]
+host = "127.0.0.1"
 port = 8080
 
 [redis]
-ip = [127,0,0,1]
+host = "127.0.0.1"
 port = 1234
 # leave them emtpy if you don't wish to an account
 username = "asdf"

--- a/src/api.rs
+++ b/src/api.rs
@@ -298,27 +298,6 @@ enum NotifyAccountState {
 }
 // --------------------------------------
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RegistrationElement {
-    accounts: Vec<(Account, VerifStatus)>,
-    request_status: VerifStatus,
-}
-
-impl RegistrationElement {
-    pub fn new(accounts: Vec<(Account, VerifStatus)>, request_status: VerifStatus) -> Self {
-        Self {
-            accounts,
-            request_status,
-        }
-    }
-
-    pub fn extend(&mut self, accounts: Vec<Account>) {
-        for account in accounts {
-            self.accounts.push((account, VerifStatus::Pending));
-        }
-    }
-}
-
 /// Spawns the Websocket client, Matrix client and the Node(substrate) listener
 pub async fn spawn_services(cfg: Config) -> anyhow::Result<()> {
     matrix::start_bot(cfg.matrix, &cfg.redis, &cfg.watcher).await?;

--- a/src/api.rs
+++ b/src/api.rs
@@ -880,13 +880,11 @@ impl RedisConnection {
     }
 
     /// Search through the redis for keys that are similar to the `pattern`
-    pub fn search(&mut self, pattern: String) -> Vec<String> {
-        let mut keys = vec![];
-        let mut res = self.conn.scan_match::<&str, String>(&pattern).unwrap();
-        while let Some(item) = res.next() {
-            keys.push(item);
-        }
-        return keys;
+    pub fn search(&mut self, pattern: String) -> anyhow::Result<Vec<String>> {
+        Ok(self
+            .conn
+            .scan_match::<&str, String>(&pattern)?
+            .collect::<Vec<String>>())
     }
 
     /// Get all pending challenges of `wallet_id` as a [Vec<Vec<String>>]
@@ -1192,7 +1190,7 @@ impl RedisConnection {
             .arg(&serde_json::to_string(who)?)
             .exec(&mut self.conn)?;
 
-        let accounts = self.search(format!("*:{}", serde_json::to_string(&who)?));
+        let accounts = self.search(format!("*:{}", serde_json::to_string(&who)?))?;
         for account in accounts {
             redis::pipe()
                 .cmd("DEL")

--- a/src/api.rs
+++ b/src/api.rs
@@ -1223,13 +1223,10 @@ impl RedisConnection {
     /// `Ok(Some(true))` - Account exist and is verified
     /// `Ok(Some(false))` - Account exist and is not verified
     /// `Ok(None)` - Account does not exist
-    /// `Err(e)` - Error occured
+    /// `Err(e)` - Error occurred
     pub fn is_verified(&mut self, account: &str) -> anyhow::Result<Option<bool>> {
-        match self.get_status(account)? {
-            Some(VerifStatus::Done) => Ok(Some(true)),
-            Some(VerifStatus::Pending) => Ok(Some(false)),
-            None => Ok(None),
-        }
+        Ok(self.get_status(account)?
+            .map(|status| matches!(status, VerifStatus::Done)))
     }
 
     /// checks if the hashshet of name `account` is in consistent with it's corresponding

--- a/src/api.rs
+++ b/src/api.rs
@@ -529,7 +529,7 @@ impl Listener {
                             "message": serde_json::json!({
                                 "info": conn.extract_info(&request.payload)?,
                                 "hash": "TODO",
-                                "pending_challenges": conn.get_challanges(&request.payload),
+                                "pending_challenges": conn.get_challenges(&request.payload),
                                 "account": request.payload,
                             }),
                         }));
@@ -892,7 +892,7 @@ impl RedisConnection {
     /// Get all pending challenges of `wallet_id` as a [Vec<Vec<String>>]
     /// The return type may look something like this (using double `[` for display purposes):
     /// [[["Discord", "asdf123"]], [["Twitter", "abcd123"]], ...]]
-    pub fn get_challanges(&mut self, wallet_id: &AccountId32) -> Vec<Vec<String>> {
+    pub fn get_challenges(&mut self, wallet_id: &AccountId32) -> Vec<Vec<String>> {
         let mut result = vec![];
         for account in self.get_accounts_from_status(wallet_id, VerifStatus::Pending) {
             match self.get_challenge_token_from_account_info(&format!(

--- a/src/api.rs
+++ b/src/api.rs
@@ -66,13 +66,7 @@ impl RequestTracker {
     }
 
     fn all_done(&self) -> bool {
-        for acc in self.req.values() {
-            match acc {
-                VerifStatus::Done => {}
-                VerifStatus::Pending => return false,
-            }
-        }
-        return true;
+        self.req.values().all(|acc| matches!(acc, VerifStatus::Done))
     }
 
     fn is_done(&self, acc: &Account) -> bool {

--- a/src/api.rs
+++ b/src/api.rs
@@ -55,31 +55,6 @@ pub struct AcctMetadata {
     pub token: Token,
 }
 
-pub struct RequestTracker {
-    pub req: HashMap<Account, VerifStatus>,
-    pub acc_id: AccountId32,
-}
-
-impl RequestTracker {
-    fn new(req: HashMap<Account, VerifStatus>, acc_id: AccountId32) -> Self {
-        Self { req, acc_id }
-    }
-
-    fn all_done(&self) -> bool {
-        self.req.values().all(|acc| matches!(acc, VerifStatus::Done))
-    }
-
-    fn is_done(&self, acc: &Account) -> bool {
-        match self.req.get(acc) {
-            Some(v) => match v {
-                VerifStatus::Done => return true,
-                VerifStatus::Pending => return false,
-            },
-            None => return false,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum Account {
     Twitter(String),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -72,7 +72,7 @@ impl RedisConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct WatcherConfig {
     pub endpoint: String,
     pub registrar_index: RegistrarIndex,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@
 use crate::node::identity::events::judgement_requested::RegistrarIndex;
 use anyhow::anyhow;
 use std::fs;
-use toml;
+use url::Url;
 
 use serde::Deserialize;
 
@@ -37,7 +37,7 @@ pub struct MatrixConfig {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct RedisConfig {
-    pub ip: [u8; 4],
+    pub host: String,
     pub port: u16,
     pub username: String,
     pub password: String,
@@ -46,7 +46,7 @@ pub struct RedisConfig {
 impl Default for RedisConfig {
     fn default() -> Self {
         Self {
-            ip: [127, 0, 0, 1],
+            host: "127.0.0.1".to_string(),
             port: 6379,
             username: String::new(),
             password: String::new(),
@@ -55,24 +55,16 @@ impl Default for RedisConfig {
 }
 
 impl RedisConfig {
-    pub fn to_full_domain(&self) -> String {
+    pub fn to_url(&self) -> Result<Url, url::ParseError> {
+        let mut url = Url::parse(&format!("redis://{}:{}/", self.host, self.port))?;
+
         if !self.username.is_empty() || !self.password.is_empty() {
-            return format!(
-                "redis://{}:{}@{}.{}.{}.{}:{}/",
-                self.username,
-                self.password,
-                self.ip[0],
-                self.ip[1],
-                self.ip[2],
-                self.ip[3],
-                self.port
-            );
-        } else {
-            return format!(
-                "redis://{}.{}.{}.{}:{}/",
-                self.ip[0], self.ip[1], self.ip[2], self.ip[3], self.port
-            );
+            url.set_username(&self.username)
+                .map_err(|()| url::ParseError::IdnaError)?;
+            url.set_password(Some(&self.password))
+                .map_err(|()| url::ParseError::IdnaError)?;
         }
+        Ok(url)
     }
 }
 
@@ -85,14 +77,14 @@ pub struct WatcherConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct WebsocketConfig {
-    pub ip: [u8; 4],
+    pub host: String,
     pub port: u16,
 }
 
 impl Default for WebsocketConfig {
     fn default() -> Self {
         Self {
-            ip: [127, 0, 0, 1],
+            host: "127.0.0.1".to_string(),
             port: 8080,
         }
     }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -276,7 +276,7 @@ async fn handle_incoming(
     let mut redis_connection = RedisConnection::create_conn(redis_cfg)?;
     // since an account could be registred by more than wallet, we need to poll each
     // instance of that account
-    let accounts = redis_connection.search(format!("{}:*", serde_json::to_string(&acc)?));
+    let accounts = redis_connection.search(format!("{}:*", serde_json::to_string(&acc)?))?;
     // TODO: handle the account VerifStatus in the HahsMap of accounts under the wallet_id
     if accounts.is_empty() {
         return Ok(());

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -315,7 +315,7 @@ async fn handle_content(
     // https://github.com/rust-lang/rust/pull/132833
     if let Ok(Some(false)) = redis_connection.is_verified(&account) {
         let challenge = redis_connection
-            .get_challenge_token_from_account_info(&account)
+            .get_challenge_token_from_account_info(&account)?
             .unwrap();
         if text_content.body.eq(&challenge.show()) {
             redis_connection.set_status(&account, VerifStatus::Done)?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -51,7 +51,8 @@ pub async fn provide_judgement<'a>(
 ) -> anyhow::Result<&'a str> {
     let client = Client::from_url(endpoint).await.map_err(|e| {
         anyhow!(
-            "unable to connect to people-rococo network because of {}",
+            "unable to connect to {} because of {}",
+            endpoint,
             e.to_string()
         )
     })?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -65,14 +65,14 @@ pub async fn provide_judgement<'a>(
         Identity::from_str(&hash)?,
     );
 
-    let singer: subxt::tx::signer::PairSigner<SubstrateConfig, subxt::ext::sp_core::sr25519::Pair> = {
+    let signer: subxt::tx::signer::PairSigner<SubstrateConfig, subxt::ext::sp_core::sr25519::Pair> = {
         // TODO: config the "//Alice" part?
         let acc = subxt::ext::sp_core::sr25519::Pair::from_string("//FERDIE", None)?;
         subxt::tx::PairSigner::new(acc)
     };
 
     let conf = subxt::config::substrate::SubstrateExtrinsicParamsBuilder::new().build();
-    match client.tx().sign_and_submit(&judgement, &singer, conf).await {
+    match client.tx().sign_and_submit(&judgement, &signer, conf).await {
         Ok(_) => return Ok("Judged with reasonable"),
         Err(_) => return Err(anyhow!("unable to submit judgement")),
     }
@@ -137,13 +137,13 @@ pub async fn register_identity<'a>(
         Identity::from_str(&hash)?,
     );
 
-    let singer: subxt::tx::signer::PairSigner<SubstrateConfig, subxt::ext::sp_core::sr25519::Pair> = {
+    let signer: subxt::tx::signer::PairSigner<SubstrateConfig, subxt::ext::sp_core::sr25519::Pair> = {
         let acc = subxt::ext::sp_core::sr25519::Pair::from_string("//ALICE", None)?;
         subxt::tx::PairSigner::new(acc)
     };
 
     let conf = subxt::config::substrate::SubstrateExtrinsicParamsBuilder::new().build();
-    match client.tx().sign_and_submit(&judgement, &singer, conf).await {
+    match client.tx().sign_and_submit(&judgement, &signer, conf).await {
         Ok(_) => return Ok("Judged with reasonable"),
         Err(e) => return Err(anyhow!("unable to submit judgement\nError: {:?}", e)),
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -14,6 +14,12 @@ pub struct Token {
     expected_message: String,
 }
 
+impl Token {
+    pub fn new(token: String) -> Self {
+        Self { expected_message: token }
+    }
+}
+
 impl From<String> for Token {
     fn from(value: String) -> Self {
         Self {


### PR DESCRIPTION
The main focus of this PR is to:
1) Properly handle all `necessary` BC events to provide a somewhat "sain" registrar behavior, those events may now include `JudgementRequested` and `JudgementUnrequested` and this pool may expand in a later commits.
2) Properly handle all WS connections as described in the [dummyapi](https://github.com/hitchhooker/dummyapi) and [W3REGAPI](https://github.com/rotkonetworks/w3registrar-www/blob/main/W3REGAPI.md).
Also, this PR may include some additional changes that we see fit/necessary to provide the described behavior above.

P.S:
Happy Holiday all of you :3 :heart: 