### PR TITLE
use less opinionated host instead of ip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio-tungstenite = "0.24.0"
 futures-util = "0.3.31"
 subxt-signer = "0.38.0"
 redis = { version = "0.27.6", features = ["aio", "json", "log", "tokio-comp", "uuid"] }
+url = "2"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,11 +4,11 @@ registrar_index = 0
 keystore_path = "./keyfile"
 
 [websocket]
-ip = [127,0,0,1]
+host = "127.0.0.1"
 port = 8080
 
 [redis]
-ip = [127,0,0,1]
+host = "127.0.0.1"
 port = 1234
 # leave them emtpy if you don't wish to an account
 username = "asdf"

--- a/src/api.rs
+++ b/src/api.rs
@@ -400,7 +400,7 @@ pub fn identity_data_tostring(data: &IdentityData) -> Option<String> {
 
 #[derive(Debug, Clone)]
 struct Listener {
-    ip: [u8; 4],
+    host: String,
     port: u16,
     redis_cfg: RedisConfig,
 }
@@ -408,7 +408,7 @@ struct Listener {
 impl Listener {
     pub async fn new(websocket_cfg: WebsocketConfig, redis_cfg: RedisConfig) -> Self {
         Self {
-            ip: websocket_cfg.ip,
+            host: websocket_cfg.host,
             port: websocket_cfg.port,
             redis_cfg,
         }
@@ -651,7 +651,7 @@ impl Listener {
     }
 
     pub async fn listen(self) -> anyhow::Result<()> {
-        let addr = SocketAddr::from((self.ip, self.port));
+        let addr = SocketAddr::from((self.host, self.port));
         let listener = TcpListener::bind(&addr).await?;
         loop {
             match listener.accept().await {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@
 use crate::node::identity::events::judgement_requested::RegistrarIndex;
 use anyhow::anyhow;
 use std::fs;
-use toml;
+use url::Url;
 
 use serde::Deserialize;
 
@@ -37,7 +37,7 @@ pub struct MatrixConfig {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct RedisConfig {
-    pub ip: [u8; 4],
+    pub host: String,
     pub port: u16,
     pub username: String,
     pub password: String,
@@ -46,7 +46,7 @@ pub struct RedisConfig {
 impl Default for RedisConfig {
     fn default() -> Self {
         Self {
-            ip: [127, 0, 0, 1],
+            host: "127.0.0.1".to_string(),
             port: 6379,
             username: String::new(),
             password: String::new(),
@@ -55,24 +55,16 @@ impl Default for RedisConfig {
 }
 
 impl RedisConfig {
-    pub fn to_full_domain(&self) -> String {
+    pub fn to_url(&self) -> Result<Url, url::ParseError> {
+        let mut url = Url::parse(&format!("redis://{}:{}/", self.host, self.port))?;
+
         if !self.username.is_empty() || !self.password.is_empty() {
-            return format!(
-                "redis://{}:{}@{}.{}.{}.{}:{}/",
-                self.username,
-                self.password,
-                self.ip[0],
-                self.ip[1],
-                self.ip[2],
-                self.ip[3],
-                self.port
-            );
-        } else {
-            return format!(
-                "redis://{}.{}.{}.{}:{}/",
-                self.ip[0], self.ip[1], self.ip[2], self.ip[3], self.port
-            );
+            url.set_username(&self.username)
+                .map_err(|()| url::ParseError::IdnaError)?;
+            url.set_password(Some(&self.password))
+                .map_err(|()| url::ParseError::IdnaError)?;
         }
+        Ok(url)
     }
 }
 
@@ -85,14 +77,14 @@ pub struct WatcherConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct WebsocketConfig {
-    pub ip: [u8; 4],
+    pub host: String,
     pub port: u16,
 }
 
 impl Default for WebsocketConfig {
     fn default() -> Self {
         Self {
-            ip: [127, 0, 0, 1],
+            host: "127.0.0.1".to_string(),
             port: 8080,
         }
     }


### PR DESCRIPTION
Using host strings instead of IP arrays allows for more flexible deployment, especially in Docker where you might need to use container names, DNS entries, or hostnames like "redis" or "postgres" instead of hard-coded IP addresses.