### PR TITLE
feat: switch to trust-dns and simplify services stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "hex-literal",
  "itoa",
  "proptest",
@@ -1597,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
 ]
@@ -2523,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -3809,54 +3809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "openssl",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tokio-openssl",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tokio-openssl",
- "tracing",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4104,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -4543,13 +4505,13 @@ dependencies = [
  "http",
  "jsonrpsee-core",
  "pin-project",
- "rustls",
+ "rustls 0.23.22",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "tracing",
  "url",
@@ -7868,7 +7830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52b5648a2e8ce1f9a0f8c41c38def670cefd91932cd793468e1a5b0b0b4e4af1"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "scale-info",
@@ -8003,7 +7965,7 @@ checksum = "1d4cdf181c2419b35c2cbde813da2d8ee777b69b4a6fa346b962d144e3521976"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -8744,7 +8706,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
- "zerocopy 0.8.14",
+ "zerocopy 0.8.15",
 ]
 
 [[package]]
@@ -8783,7 +8745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.14",
+ "zerocopy 0.8.15",
 ]
 
 [[package]]
@@ -8994,7 +8956,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -9474,6 +9436,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
@@ -9482,7 +9456,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -9494,10 +9468,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -9526,13 +9509,13 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.22",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots",
+ "webpki-roots 0.26.8",
  "winapi",
 ]
 
@@ -9541,6 +9524,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -9578,7 +9571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
 ]
 
 [[package]]
@@ -9901,6 +9894,16 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -10329,7 +10332,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "ed25519-zebra",
  "either",
  "event-listener",
@@ -10379,7 +10382,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "either",
  "event-listener",
  "fnv",
@@ -12305,13 +12308,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.5"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "openssl",
- "openssl-sys",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -12321,7 +12323,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls",
+ "rustls 0.23.22",
  "tokio",
 ]
 
@@ -12518,6 +12520,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "rustls-webpki 0.101.7",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "rustls 0.21.12",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "trust-dns-proto",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12633,6 +12688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12688,7 +12749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.0.3",
  "percent-encoding",
  "serde",
 ]
@@ -12853,7 +12914,6 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "hickory-resolver",
  "imap",
  "mail-parser",
  "matrix-sdk",
@@ -12876,6 +12936,7 @@ dependencies = [
  "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
+ "trust-dns-resolver",
  "tungstenite",
  "url",
  "uuid",
@@ -13333,6 +13394,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
@@ -13665,9 +13732,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]
@@ -13839,11 +13906,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+checksum = "a1e101d4bc320b6f9abb68846837b70e25e380ca2f467ab494bf29fcc435fcc3"
 dependencies = [
- "zerocopy-derive 0.8.14",
+ "zerocopy-derive 0.8.15",
 ]
 
 [[package]]
@@ -13859,9 +13926,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+checksum = "03a73df1008145cd135b3c780d275c57c3e6ba8324a41bd5e0008fe167c3bc7c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ imap = "2.4.1"
 native-tls = "0.2.12"
 mail-parser = "0.10"
 regex = "1.11.1"
-# dns-over-rustls broken in hickory
-hickory-resolver = { version = "^0.24", features = ["dns-over-openssl"] }
+# hickory tls unstable, locking to trust-dns
+trust-dns-resolver = { version = "=0.23.2", features = ["dns-over-rustls"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/adapter/dns.rs
+++ b/src/adapter/dns.rs
@@ -1,15 +1,15 @@
 use crate::{api::RedisConnection, config::GLOBAL_CONFIG, node::register_identity};
 use anyhow::Result;
-use trust_dns_resolver::{
-    config::{ResolverConfig, ResolverOpts},
-    name_server::TokioConnectionProvider,
-    AsyncResolver,
-    proto::rr::{RecordType, RData},
-};
 use std::str::FromStr;
 use subxt::utils::AccountId32;
 use tokio::time::{sleep, Duration};
 use tracing::{error, info};
+use trust_dns_resolver::{
+    config::{ResolverConfig, ResolverOpts},
+    name_server::TokioConnectionProvider,
+    proto::rr::{RData, RecordType},
+    AsyncResolver,
+};
 
 const DNS_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -17,15 +17,20 @@ async fn lookup_txt_records(
     domain: &str,
     resolver: &AsyncResolver<TokioConnectionProvider>,
 ) -> Result<Vec<String>, String> {
-    resolver.lookup(domain, RecordType::TXT).await
-        .map(|response| response.iter()
-            .filter_map(|record| match record {
-                RData::TXT(txt_data) => Some(txt_data),
-                _ => None,
-            })
-            .flat_map(|txt_data| txt_data.iter())
-            .map(|bytes| String::from_utf8_lossy(bytes).to_string())
-            .collect())
+    resolver
+        .lookup(domain, RecordType::TXT)
+        .await
+        .map(|response| {
+            response
+                .iter()
+                .filter_map(|record| match record {
+                    RData::TXT(txt_data) => Some(txt_data),
+                    _ => None,
+                })
+                .flat_map(|txt_data| txt_data.iter())
+                .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+                .collect()
+        })
         .map_err(|e| e.to_string())
 }
 
@@ -64,27 +69,29 @@ impl DnsChallenge {
             return Ok(None);
         }
 
-        let domain = parts[1].to_string()
+        let domain = parts[1]
+            .to_string()
             .trim_start_matches("https://")
             .trim_start_matches("http://")
             .trim_end_matches('/')
             .to_string();
-            
+
         let network = parts[2].to_string();
         let account_id = AccountId32::from_str(parts[3])?;
 
-        let state = match redis_conn.get_verification_state(&network, &account_id).await? {
+        let state = match redis_conn
+            .get_verification_state(&network, &account_id)
+            .await?
+        {
             Some(s) => s,
             None => return Ok(None),
         };
 
         let token = match state.challenges.get("web") {
-            Some(challenge) if !challenge.done => {
-                match &challenge.token {
-                    Some(t) => t.clone(),
-                    None => return Ok(None),
-                }
-            }
+            Some(challenge) if !challenge.done => match &challenge.token {
+                Some(t) => t.clone(),
+                None => return Ok(None),
+            },
             _ => return Ok(None),
         };
 
@@ -101,12 +108,17 @@ impl DnsChallenge {
             return Ok(());
         }
 
-        redis_conn.update_challenge_status(&self.network, &self.account_id, "web").await?;
+        redis_conn
+            .update_challenge_status(&self.network, &self.account_id, "web")
+            .await?;
         self.check_completion(redis_conn).await
     }
 
     async fn check_completion(&self, redis_conn: &mut RedisConnection) -> Result<()> {
-        if let Some(state) = redis_conn.get_verification_state(&self.network, &self.account_id).await? {
+        if let Some(state) = redis_conn
+            .get_verification_state(&self.network, &self.account_id)
+            .await?
+        {
             if state.all_done {
                 register_identity(&self.account_id, &self.network).await?;
             }
@@ -116,9 +128,11 @@ impl DnsChallenge {
 }
 
 pub async fn watch_dns() -> Result<()> {
-    let cfg = GLOBAL_CONFIG.get().expect("GLOBAL_CONFIG is not initialized");
+    let cfg = GLOBAL_CONFIG
+        .get()
+        .expect("GLOBAL_CONFIG is not initialized");
     let mut redis_conn = RedisConnection::create_conn(&cfg.redis)?;
-    
+
     loop {
         if let Err(e) = process_challenges(&mut redis_conn).await {
             error!("DNS challenge processing error: {}", e);
@@ -136,7 +150,10 @@ async fn process_challenges(redis_conn: &mut RedisConnection) -> Result<()> {
     Ok(())
 }
 
-async fn process_single_challenge(challenge_key: &str, redis_conn: &mut RedisConnection) -> Result<()> {
+async fn process_single_challenge(
+    challenge_key: &str,
+    redis_conn: &mut RedisConnection,
+) -> Result<()> {
     if let Some(challenge) = DnsChallenge::from_key(challenge_key, redis_conn).await? {
         challenge.verify(redis_conn).await?;
     }

--- a/src/adapter/dns.rs
+++ b/src/adapter/dns.rs
@@ -37,6 +37,7 @@ pub async fn verify_txt(domain: &str, challenge: &str) -> bool {
                 info!("Found {}:{}:{}", domain, challenge, record);
             }
             if records.contains(&challenge.to_string()) {
+                info!("TXT record verification successful for {}", domain);
                 return true;
             }
             info!("No matching({}) TXT record found", &challenge.to_string());

--- a/src/api.rs
+++ b/src/api.rs
@@ -301,19 +301,14 @@ impl FromStr for Account {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let matrix_regex =
-            Regex::new(r"@(?<name>\w+):(?<domain_name>\w+).(?<top_domain>\w+)").unwrap();
+        let matrix_regex = Regex::new(r"@(?<name>[a-z0-9][a-z0-9.=/-]*):(?<domain>(?:[a-zA-Z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::\d{1,5})?)").unwrap();
         info!("Determining that account {s} is a valid format...");
         match matrix_regex.captures(s) {
             Some(account) => {
                 info!("This {s} is a matrix account");
                 let acc_name: &str = &account["name"];
-                let domain_name: &str = &account["domain_name"];
-                let top_level: &str = &account["top_domain"];
-                return Ok(Self::Matrix(format!(
-                    "@{}:{}.{}",
-                    acc_name, domain_name, top_level
-                )));
+                let domain: &str = &account["domain"];
+                return Ok(Self::Matrix(format!("@{}:{}", acc_name, domain)));
             }
             None => {
                 let (account_type, value) = s

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,6 +64,17 @@ pub struct RegistrarConfig {
 }
 
 impl Config {
+
+    /// Set the [GLOBAL_CONFIG] global variable and return an instance(clone) of it
+    pub fn set_global_config() -> anyhow::Result<Config> {
+        let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.toml".to_string());
+        let config = Config::load_from(&config_path)?;
+        GLOBAL_CONFIG
+            .set(config.clone())
+            .expect("GLOBAL_CONFIG already initialized");
+        Ok(config)
+    }
+
     pub fn load_from(path: &str) -> anyhow::Result<Self> {
         let absolute_path =
             std::fs::canonicalize(path).unwrap_or_else(|_| std::path::PathBuf::from(path));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,10 +64,10 @@ pub struct RegistrarConfig {
 }
 
 impl Config {
-
     /// Set the [GLOBAL_CONFIG] global variable and return an instance(clone) of it
     pub fn set_global_config() -> anyhow::Result<Config> {
-        let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.toml".to_string());
+        let config_path =
+            std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.toml".to_string());
         let config = Config::load_from(&config_path)?;
         GLOBAL_CONFIG
             .set(config.clone())

--- a/src/email.rs
+++ b/src/email.rs
@@ -225,30 +225,6 @@ impl MailServer {
         .map_err(|_| anyhow!("Timeout during login"))?
         .expect("Unable to login!");
 
-        // for debugging print last mail
-        //session
-        //    .select(email_cfg.mailbox.clone())
-        //    .expect("Unable to select mailbox");
-        //
-        //let msgs = session.search("ALL")?;
-        //if let Some(max_uid) = msgs.iter().max() {
-        //    // If there's at least one message, we try to fetch & parse it
-        //    let fetches = session.uid_fetch(format!("{}", max_uid), "RFC822")?;
-        //    if let Some(msg) = fetches.get(0) {
-        //        let parsed = mail_parser::MessageParser::default()
-        //            .parse(msg.body().unwrap_or_default())
-        //            .unwrap_or_default();
-        //        let from = parsed.return_address().unwrap_or("(no sender)").to_string();
-        //        let subject = parsed.subject().unwrap_or("(no subject)").to_string();
-        //        info!(
-        //            "Last email in mailbox => from: {}, subject: {}",
-        //            from, subject
-        //        );
-        //    }
-        //} else {
-        //    info!("No messages found in mailbox.");
-        //}
-
         info!("Sucessfull login to mail account {}", email_cfg.email);
 
         Ok(Self {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,30 @@
+use tokio::task::JoinHandle;
+use tracing::info;
+/// NOTE: I hate how short this file is
+
+#[derive(Default)]
+pub struct Runner {
+    handlers: Vec<JoinHandle<()>>,
+}
+
+impl Runner {
+    /// Push a job to the queue
+    pub async fn push(&mut self, handler: JoinHandle<()>) {
+        self.handlers.push(handler);
+    }
+
+    /// Run jobs, Ctr-C for gracefully shutdown
+    pub async fn run(self) {
+        info!("Spawning {} jobs", self.handlers.len());
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("Shutdown signal received");
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                std::process::exit(0);
+            }
+            _ = futures::future::join_all(self.handlers) => {
+                info!("All services completed");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- replaces hickory-resolver with trust-dns-resolver for DNS resolution
- adds Runner abstraction for managing service lifecycles
- improves logging and error handling in email services
- updates matrix account regex pattern
- refactors DNS challenge verification logic