### PR TITLE
refactor: consolidate initial `tokio::spawn` under a common fn

### DIFF
--- a/src/adapter/dns.rs
+++ b/src/adapter/dns.rs
@@ -127,7 +127,7 @@ impl DnsChallenge {
     }
 }
 
-pub async fn watch_dns() -> Result<()> {
+pub async fn watch_dns() -> anyhow::Result<()> {
     let cfg = GLOBAL_CONFIG
         .get()
         .expect("GLOBAL_CONFIG is not initialized");

--- a/src/api.rs
+++ b/src/api.rs
@@ -1544,7 +1544,8 @@ impl Default for VerificationFields {
     }
 }
 
-pub async fn spawn_redis_subscriber(redis_cfg: RedisConfig) -> anyhow::Result<()> {
+pub async fn spawn_redis_subscriber() -> anyhow::Result<()> {
+    let redis_cfg = GLOBAL_CONFIG.get().unwrap().redis.clone();
     let span = span!(Level::INFO, "redis_subscriber");
     info!(parent: &span, "Starting Redis subscriber service");
 


### PR DESCRIPTION
This is a polishing/refactoring for the main function, since it has some-almost-identical `tokio::spanw`s, I've chosen to move those under the `Runner::push` that "atuomagically" spawns those tokio tasks for you reducing the overall boilerplate.