### PR TITLE
fix: refresh `IDLE` mail connection after `x` seconds

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -312,11 +312,14 @@ impl MailServer {
     /// Polls mailbox for new unread messages and processes them
     /// Uses IMAP IDLE for efficient notification of new messages
     async fn check_mailbox(&mut self) -> anyhow::Result<()> {
-        let idle_handle = self.session.idle()?;
+        let mut idle_handle = self.session.idle()?;
         info!("Waiting for incoming mails...");
 
+        // TODO: make this duration cofigurable
+        idle_handle.set_keepalive(Duration::from_secs(60));
+
         idle_handle
-            .wait()
+            .wait_keepalive()
             .map_err(|e| anyhow!("IMAP IDLE error: {}", e))?;
         info!("Received new mail notification");
 


### PR DESCRIPTION
Before, we used to timeout frequently duo to server-side dropping the connection after a client being `IDLE` for a certain time and because we used the `wait` method to listen for mail events, which do not account for that behavior, and now we use the `wait_keepalive` method specified here which basically refreshes the connection every x seconds
    https://docs.rs/imap/latest/imap/extensions/idle/struct.Handle.html#method.wait_keepalive