### PR TITLE
Refactor: Move `matrix` and `mail` under adapters module

### DIFF
--- a/src/adapter/mail.rs
+++ b/src/adapter/mail.rs
@@ -312,11 +312,14 @@ impl MailServer {
     /// Polls mailbox for new unread messages and processes them
     /// Uses IMAP IDLE for efficient notification of new messages
     async fn check_mailbox(&mut self) -> anyhow::Result<()> {
-        let idle_handle = self.session.idle()?;
+        let mut idle_handle = self.session.idle()?;
         info!("Waiting for incoming mails...");
 
+        // TODO: make this duration cofigurable
+        idle_handle.set_keepalive(Duration::from_secs(60));
+
         idle_handle
-            .wait()
+            .wait_keepalive()
             .map_err(|e| anyhow!("IMAP IDLE error: {}", e))?;
         info!("Received new mail notification");
 

--- a/src/adapter/matrix.rs
+++ b/src/adapter/matrix.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::{adapter::Adapter, config::MatrixConfig};
+use crate::adapter::Adapter;
 use matrix_sdk::{
     config::{RequestConfig, StoreConfig, SyncSettings},
     deserialized_responses::RawSyncOrStrippedState,
@@ -21,7 +21,6 @@ use matrix_sdk::{
     },
     Client,
 };
-use redis;
 use serde_json::Value;
 use std::str::FromStr;
 use subxt::utils::AccountId32;

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,4 +1,3 @@
-use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use subxt::utils::AccountId32;
 use tracing::info;
 
@@ -7,9 +6,10 @@ use crate::{
     node::register_identity,
 };
 
-// TODO: add other mods (matrix + mail)
 
 pub mod dns;
+pub mod mail;
+pub mod matrix;
 
 pub trait Adapter {
     async fn handle_content(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,14 @@
 mod adapter;
 mod api;
 mod config;
-mod email;
-mod matrix;
 mod node;
 mod runner;
 mod token;
 
 use crate::adapter::dns::watch_dns;
+use crate::adapter::{mail::watch_mailserver, matrix};
 use crate::api::{spawn_node_listener, spawn_redis_subscriber, spawn_ws_serv};
 use crate::config::{Config, GLOBAL_CONFIG};
-use crate::email::watch_mailserver;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 


### PR DESCRIPTION
This moves the `src/matrix.rs` and `src/email.rs` to `src/adapter/matrix.rs` and `src/adapter/mail.rs` respectively.