### PR TITLE
Notify account state

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ pkgs.mkShell {
     clang
     llvm
     libiconv
+    redis
   ];
 
   LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     node::register_identity,
 };
 
-
 pub mod dns;
 pub mod mail;
 pub mod matrix;

--- a/src/api.rs
+++ b/src/api.rs
@@ -604,7 +604,6 @@ impl Listener {
         conn.init_verification_state(network, &request.payload, &verification, &accounts)
             .await?;
 
-
         // everything below is unchanged: hashing, building JSON response, etc.
         let hash = self.hash_identity_info(&registration.info);
 


### PR DESCRIPTION
very redundant addition tbf. but turns out we been sending updates in very wrong formating to frontend about our state leading that it cant parse those
wrong:
```
        Ok(Some((
            id,
            serde_json::json!({
                "type": "AccountState",
                "network": network,
                "verification_state": state,
                "operation": payload,
            }),
        )))
```
 should be same as intiial