### PR TITLE
Fix account state updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "w3registrar"
-version = "0.4.2"
+version = "0.4.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
fix:  use same format for account state JSON handling

- Remove unused `NotifyAccountState` variant and its enum.
- Centralize JSON response building via the new `build_account_state_message` helper.
- Update `process_state_change` to return a vector of JSON messages.
- make script to take endpoints as optional argument