### PR TITLE
fix(redis): implement connection pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8800,13 +8809,15 @@ checksum = "188bbae3aa4739bd264e9204da5919b2c91dd87dcce5049cf04bdf6aa17c5012"
 
 [[package]]
 name = "redis"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
+checksum = "9568894e8bdefd16512bca9e286a9d2abc27773609aa4eb7f428497d64df4373"
 dependencies = [
  "arc-swap",
+ "backon",
  "bytes",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sp-core = "35.0.0"
 tokio-tungstenite = "0.26.0"
 futures-util = "0.3.31"
 subxt-signer = "0.38"
-redis = { version = "0.28", features = ["aio", "json", "tokio-comp", "uuid"] }
+redis = { version = "0.29", features = ["connection-manager", "json", "tokio-comp", "uuid"] }
 url = "2"
 once_cell = "1.20"
 tungstenite = "0.26.1"

--- a/src/adapter/dns.rs
+++ b/src/adapter/dns.rs
@@ -131,7 +131,7 @@ pub async fn watch_dns() -> anyhow::Result<()> {
     let cfg = GLOBAL_CONFIG
         .get()
         .expect("GLOBAL_CONFIG is not initialized");
-    let mut redis_conn = RedisConnection::create_conn(&cfg.redis)?;
+    let mut redis_conn = RedisConnection::get_connection(&cfg.redis)?;
 
     loop {
         if let Err(e) = process_challenges(&mut redis_conn).await {

--- a/src/adapter/mail.rs
+++ b/src/adapter/mail.rs
@@ -45,7 +45,7 @@ impl Mail {
     /// and uses the Adapter trait's handle_content implementation for validation.
     async fn process_email(&self, redis_cfg: &RedisConfig) -> anyhow::Result<()> {
         let account = Account::Email(self.sender.clone());
-        let mut redis_connection = RedisConnection::create_conn(redis_cfg)?;
+        let mut redis_connection = RedisConnection::get_connection(redis_cfg)?;
 
         let search_query = format!("{}|*", account);
         let accounts = redis_connection.search(&search_query)?;

--- a/src/adapter/matrix.rs
+++ b/src/adapter/matrix.rs
@@ -280,7 +280,7 @@ impl Matrix {
         );
         let cfg = GLOBAL_CONFIG.get().unwrap();
         let redis_cfg = cfg.redis.clone();
-        let mut redis_connection = RedisConnection::create_conn(&redis_cfg)?;
+        let mut redis_connection = RedisConnection::get_connection(&redis_cfg)?;
         let query = format!("{}|*", acc);
         info!("Search query: {}", query);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{
     adapter::{dns::watch_dns, mail::watch_mailserver, matrix},
-    api::{spawn_node_listener, spawn_redis_subscriber, spawn_ws_serv},
+    api::{spawn_node_listener, spawn_redis_subscriber, spawn_ws_serv, RedisConnection},
     config::{Config, GLOBAL_CONFIG},
 };
 
@@ -86,6 +86,9 @@ async fn main() -> Result<()> {
     // load configuration
     let config =
         Config::set_global_config().context("failed to load and set global configuration")?;
+
+    // init redis conn pool
+    RedisConnection::initialize_pool(&config.redis)?;
 
     // initialize runner
     let mut runner = runner::Runner::new();


### PR DESCRIPTION
- Add global Redis client pool using OnceCell
- Update redis crate to 0.29 and use connection-manager feature
- Split connection handling into initialize_pool and get_connection
- Replace create_conn calls with get_connection across codebase
- Initialize Redis pool at startup in main.rs

Change reduces the number of Redis connections by reusing them through a shared client pool, improving resource usage and connection handling.