### PR TITLE
Fix(#46): put timout on reading keyspace notifications

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1162,6 +1162,12 @@ impl Listener {
                 network.as_str().unwrap_or_default(),
             );
 
+            let timeout = std::time::Duration::from_secs(10);
+            info!("Setting notification read timeout to {:?}", timeout);
+            pubsub
+                .set_read_timeout(Some(timeout))
+                .unwrap();
+
             info!("Subscribing to channel: {}", channel);
             if let Err(e) = pubsub.subscribe(&channel) {
                 error!("Failed to subscribe to channel: {}", e);


### PR DESCRIPTION
Before, if we spawn too many connections, the subscribe method fort he pubsub instance seem to block the whole program, which because it waits notification indefinitely and holds the redis connection thus resulting in a deadlock, but now after setting the timeout, the reading operation ends either after the timeout or when a read operation succeeded thus unblocking the deadlock.