### PR TITLE
improved email logging and simplified polling approach

### DIFF
--- a/src/adapter/dns.rs
+++ b/src/adapter/dns.rs
@@ -148,7 +148,7 @@ pub async fn watch_dns() -> anyhow::Result<()> {
         let cfg = GLOBAL_CONFIG
             .get()
             .expect("GLOBAL_CONFIG is not initialized");
-        let mut redis_conn = RedisConnection::get_connection(&cfg.redis)?;
+        let mut redis_conn = RedisConnection::get_connection(&cfg.redis).await?;
 
         if let Err(e) = process_challenges(&mut redis_conn).await {
             error!("DNS challenge processing error: {}", e);
@@ -159,9 +159,7 @@ pub async fn watch_dns() -> anyhow::Result<()> {
 }
 
 async fn process_challenges(redis_conn: &mut RedisConnection) -> Result<()> {
-    let challenge_keys = redis_conn.search("web|*")?;
-
-    const BATCH_SIZE: usize = 10;
+    let challenge_keys = redis_conn.search("web|*").await?;
 
     for challenge_key in &challenge_keys {
         if let Err(e) = process_single_challenge(challenge_key, redis_conn).await {
@@ -193,7 +191,7 @@ pub async fn _verify_dns_challenge(
     let cfg = GLOBAL_CONFIG
         .get()
         .expect("GLOBAL_CONFIG is not initialized");
-    let mut redis_conn = RedisConnection::get_connection(&cfg.redis)?;
+    let mut redis_conn = RedisConnection::get_connection(&cfg.redis).await?;
 
     let clean_domain = domain
         .trim()

--- a/src/adapter/mail.rs
+++ b/src/adapter/mail.rs
@@ -132,10 +132,7 @@ impl MailServer {
     }
 
     fn new() -> Option<Self> {
-        let (session, redis_cfg, mailbox) = match Self::connect() {
-            Some(connection) => connection,
-            None => return None,
-        };
+        let (session, redis_cfg, mailbox) = Self::connect()?;
 
         Some(Self {
             session,
@@ -157,7 +154,10 @@ impl MailServer {
             .to_string();
 
         // use UNSEEN or not?
-        let unseen_ids = match self.session.search(&format!("UNSEEN SENTSINCE {}", search_date)) {
+        let unseen_ids = match self
+            .session
+            .search(format!("UNSEEN SENTSINCE {}", search_date))
+        {
             Ok(ids) => ids,
             Err(e) => {
                 error!("Search failed: {}", e);
@@ -203,7 +203,7 @@ impl MailServer {
         }
 
         let mail = fetch_result
-            .get(0)
+            .first()
             .ok_or_else(|| anyhow!("Failed to get email {}", id))?;
 
         let parsed = mail_parser::MessageParser::default()

--- a/src/adapter/mail.rs
+++ b/src/adapter/mail.rs
@@ -45,10 +45,10 @@ impl Mail {
     /// and uses the Adapter trait's handle_content implementation for validation.
     async fn process_email(&self, redis_cfg: &RedisConfig) -> anyhow::Result<()> {
         let account = Account::Email(self.sender.clone());
-        let mut redis_connection = RedisConnection::get_connection(redis_cfg)?;
+        let mut redis_connection = RedisConnection::get_connection(redis_cfg).await?;
 
         let search_query = format!("{}|*", account);
-        let accounts = redis_connection.search(&search_query)?;
+        let accounts = redis_connection.search(&search_query).await?;
 
         if accounts.is_empty() {
             info!("No account found for {}", search_query);
@@ -176,8 +176,6 @@ impl MailServer {
             .expect("Unable to select mailbox");
         info!("Selected mailbox `{}`", self.mailbox);
 
-        info!("Checking existing emails on startup...");
-        self.check_mailbox().await?;
 
         loop {
             if let Err(e) = self.check_mailbox().await {

--- a/src/adapter/mail.rs
+++ b/src/adapter/mail.rs
@@ -149,14 +149,13 @@ impl MailServer {
 
         info!("Checking for emails in {}", self.mailbox);
 
-        let search_date = (chrono::Utc::now() - chrono::Duration::hours(24))
+        let search_date = (chrono::Utc::now() - chrono::Duration::minutes(30))
             .format("%d-%b-%Y")
             .to_string();
 
-        // use UNSEEN or not?
         let unseen_ids = match self
             .session
-            .search(format!("UNSEEN SENTSINCE {}", search_date))
+            .search(format!("SENTSINCE {}", search_date))
         {
             Ok(ids) => ids,
             Err(e) => {

--- a/src/adapter/matrix.rs
+++ b/src/adapter/matrix.rs
@@ -280,11 +280,11 @@ impl Matrix {
         );
         let cfg = GLOBAL_CONFIG.get().unwrap();
         let redis_cfg = cfg.redis.clone();
-        let mut redis_connection = RedisConnection::get_connection(&redis_cfg)?;
+        let mut redis_connection = RedisConnection::get_connection(&redis_cfg).await?;
         let query = format!("{}|*", acc);
         info!("Search query: {}", query);
 
-        let accounts_key = redis_connection.search(&query)?;
+        let accounts_key = redis_connection.search(&query).await?;
 
         if accounts_key.is_empty() {
             return Ok(());

--- a/src/api.rs
+++ b/src/api.rs
@@ -1711,7 +1711,7 @@ impl RedisConnection {
         who: &AccountId32,
     ) -> anyhow::Result<()> {
         let mut pipe = redis::pipe();
-        pipe.cmd("DEL").arg(&format!("{}|{}", who, network));
+        pipe.cmd("DEL").arg(format!("{}|{}", who, network));
 
         let accounts = self.search(&format!("*|{}|{}", network, who)).await?;
         for account in accounts {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -221,7 +221,7 @@ fn load_signer(network_cfg: &crate::config::RegistrarConfig) -> Result<PairSigne
     let seed = std::fs::read_to_string(&network_cfg.keystore_path)
         .map_err(|e| anyhow!("Failed to read keystore: {}", e))?;
 
-    let acc = Sr25519Pair::from_string(&seed.trim(), None)?;
+    let acc = Sr25519Pair::from_string(seed.trim(), None)?;
     let signer = PairSigner::new(acc);
 
     info!("Signer account: {}", signer.account_id());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,5 @@
-// runner.rs
-use std::collections::HashMap;
 use std::future::Future;
+use std::collections::HashMap;
 use tokio::{sync::broadcast, task::JoinHandle, time::Duration};
 use tracing::{error, info};
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,5 @@
-use std::future::Future;
 use std::collections::HashMap;
+use std::future::Future;
 use tokio::{sync::broadcast, task::JoinHandle, time::Duration};
 use tracing::{error, info};
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -36,14 +36,11 @@ mod test {
             .await
             .unwrap();
         while let stream = tx.next().await {
-            match stream {
-                Some(data) => {
-                    if let Ok(msg) = data {
-                        println!("recived: {}\n", msg);
-                        break;
-                    }
+            if let Some(data) = stream {
+                if let Ok(msg) = data {
+                    println!("recived: {}\n", msg);
+                    break;
                 }
-                None => {}
             }
         }
         let request_verification_challange_msg = to_string_pretty(&serde_json::json!({
@@ -60,14 +57,11 @@ mod test {
             .await
             .unwrap();
         while let stream = tx.next().await {
-            match stream {
-                Some(data) => {
-                    if let Ok(msg) = data {
-                        println!("recived: {}\n", msg);
-                        break;
-                    }
+            if let Some(data) = stream {
+                if let Ok(msg) = data {
+                    println!("recived: {}\n", msg);
+                    break;
                 }
-                None => {}
             }
         }
     }
@@ -88,14 +82,11 @@ mod test {
             .await
             .unwrap();
         while let stream = tx.next().await {
-            match stream {
-                Some(data) => {
-                    if let Ok(msg) = data {
-                        println!("recived: {}\n", msg);
-                        break;
-                    }
+            if let Some(data) = stream {
+                if let Ok(msg) = data {
+                    println!("recived: {}\n", msg);
+                    break;
                 }
-                None => {}
             }
         }
     }
@@ -116,14 +107,11 @@ mod test {
             .await
             .unwrap();
         while let stream = tx.next().await {
-            match stream {
-                Some(data) => {
-                    if let Ok(msg) = data {
-                        println!("recived: {}\n", msg);
-                        break;
-                    }
+            if let Some(data) = stream {
+                if let Ok(msg) = data {
+                    println!("recived: {}\n", msg);
+                    break;
                 }
-                None => {}
             }
         }
         let verify_identity_msg = to_string_pretty(&serde_json::json!({
@@ -139,14 +127,11 @@ mod test {
         println!("seinding: {}\n", verify_identity_msg);
         rx.send(Message::from(verify_identity_msg)).await.unwrap();
         while let stream = tx.next().await {
-            match stream {
-                Some(data) => {
-                    if let Ok(msg) = data {
-                        println!("recived: {}\n", msg);
-                        break;
-                    }
+            if let Some(data) = stream {
+                if let Ok(msg) = data {
+                    println!("recived: {}\n", msg);
+                    break;
                 }
-                None => {}
             }
         }
     }


### PR DESCRIPTION
change the mail adapter to back use a simple polling approach instead of imap idle. the change simplifies our design

- add 'verification:' and 'mail:' prefixes to logs for better filtering
- explicitly log success and failure states for verification attempts 
- make logs more concise to reduce noise in production
- remove unnecessary documentation comments and simplify code
- poll the email server every 30 seconds instead of using imap idle
- fix various minor code quality issues across the codebase

these changes improve our ability to track verification processes while making the code more maintainable. the simpler polling approach is more reliable with our current infrastructure until we implement a proper async mail solution or add option for jmap(preferably for our won usage, async imap does not look taht great experience )