### PR TITLE
feat: add healthcheck and autoheal configuration to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,40 @@ services:
       - CONFIG_PATH=/etc/w3registrar/config.toml
       - RUST_LOG=info
       - KEYFILE_PATH=/etc/w3registrar/keyfile
+    labels:
+      # Please make sure to run autoheal container to enable restart if the container is unhealthy
+      autoheal: true
+    healthcheck:
+      test: |
+        echo $(
+          echo '{
+            "version":"1.0",
+            "type":"SubscribeAccountState",
+            "payload":{
+              "account":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+              "network":"paseo"
+            }
+          }' 
+        ) \
+        | websocat ws://127.0.0.1:${W3REG_PORT:-8080} \
+        | jq 'select(.type == "JsonResult")
+          | select(
+            .payload.message.AccountState.account and
+            .payload.message.AccountState.hashed_info and
+            .payload.message.AccountState.network and
+            (.payload.message.AccountState.pending_challenges | type == "array") and
+            (.payload.message.AccountState.verification_state.fields | type == "object")
+          )
+          | select(
+            all(.payload.message.AccountState.pending_challenges[]; 
+              (type=="array" and length == 2 and (.[0] | type == "string") and (.[1] | type == "string"))
+            )
+          )
+        '
+      interval: 20s
+      timeout: 10s
+      retries: 3
+
 
 volumes:
   redis_data:


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yaml` file to enhance the reliability and health monitoring of the services. The most important changes include the addition of labels and a health check configuration.

Enhancements to service reliability and monitoring:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R42-R75): Added `labels` to enable the `autoheal` feature, ensuring `w3registrar` restarts if it becomes unhealthy.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R42-R75): Introduced a `healthcheck` configuration to monitor the container's health by subscribing to account state and verifying specific fields. The health check runs every 20 seconds, with a timeout of 10 seconds and up to 3 retries.