### PR TITLE
fix: libclang build with linking error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,21 @@
-FROM rust:alpine AS builder
-RUN apk add --no-cache \
-    musl-dev \
-    openssl-dev \
-    openssl-libs-static \
-    sqlite-dev \
-    sqlite-libs \
-    sqlite-static \
-    git
+FROM rust:latest AS builder
 
+RUN apt-get update 
+RUN apt-get install -y build-essential libssl-dev libsqlite3-dev git nettle-dev llvm libclang-dev
+RUN rm -rf /var/lib/apt/lists/*
 RUN git config --global net.git-fetch-with-cli true
 
 WORKDIR /usr/src/w3registrar
 COPY . .
-RUN rustup target add x86_64-unknown-linux-musl && \
-    cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo install --path ./
 
-FROM alpine
-RUN apk add --no-cache \
-    openssl \
-    ca-certificates && \
-    mkdir -p /etc/w3registrar && \
-    addgroup -S w3r && \
-    adduser -S w3r -G w3r && \
-    chown -R w3r:w3r /etc/w3registrar
+FROM rust:latest
+RUN addgroup w3r
+RUN adduser --no-create-home --ingroup w3r w3r
+RUN mkdir -p /etc/w3registrar
+RUN chown -R w3r:w3r /etc/w3registrar
 
-COPY --from=builder /usr/src/w3registrar/target/x86_64-unknown-linux-musl/release/w3registrar /usr/local/bin/
+COPY --from=builder /usr/local/cargo/bin/w3registrar /usr/bin/
 USER w3r
 WORKDIR /etc/w3registrar
 CMD ["w3registrar"]


### PR DESCRIPTION
Moved to the Rust official docker image instead of fixing the linking error, since it requires installing the deps, twice :) one on the building environment and second on the runtime environment.