### PR TITLE
feat: implement Github OAuth for registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ mail-parser = "0.10"
 regex = "1.11.1"
 # hickory tls unstable, locking to trust-dns
 trust-dns-resolver = { version = "=0.23.2", features = ["dns-over-rustls"] }
+axum = "0.8.3"
+reqwest = { version = "0.12.15", features = ["json"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/config.example.toml
+++ b/config.example.toml
@@ -14,6 +14,10 @@ keystore_path = "./.keyfile.example"
 registrar_account = "12BtBrcorHAvSeTLYo6YTq8kdiRG948vkvmxHEmSzZjwZ97u"
 fields = ["email","matrix", "twitter", "discord", "display_name"]
 
+[http]
+host = "0.0.0.0"
+port = 3000
+
 [websocket]
 host = "0.0.0.0"
 port = 8080
@@ -42,3 +46,9 @@ name = "w3registrar"
 mailbox = "INBOX"
 server = "mail.rotko.net"
 port = 143                # IMAPS port
+
+[adapter.github]
+client_id = "..."
+client_secret = "..."
+gh_url = "https://github.com/login/oauth/authorize"
+redirect_url = "http://example.com/oauth/callback/github"

--- a/src/adapter/github.rs
+++ b/src/adapter/github.rs
@@ -1,0 +1,155 @@
+/// ! For more info, check https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+///
+use crate::{
+    adapter::Adapter,
+    config::GLOBAL_CONFIG,
+    token::{AuthToken, Token},
+};
+use reqwest::{header::ACCEPT, Client};
+use serde::Deserialize;
+
+/// Used to interract with the github api
+#[derive(Clone, Debug)]
+pub struct Github {
+    pub cred: GithubCred,
+}
+
+// TODO: make a derive macro?
+impl Adapter for Github {}
+
+impl Github {
+    /// Reconstruct the redirected url with the appended state (challenge)
+    pub fn reconstruct_request_url(state: &str) -> url::Url {
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+        let gh_config = cfg.adapter.github.clone();
+        let base_url = gh_config.gh_url;
+        let client_id = gh_config.client_id;
+        let redirect_uri = gh_config
+            .redirect_url
+            .unwrap_or(url::Url::parse("https://rotko.net/").unwrap());
+
+        url::Url::parse_with_params(
+            base_url.as_str(),
+            &[
+                ("client_id", client_id.as_str()),
+                ("redirect_uri", redirect_uri.as_str()),
+                ("state", state), // this number corresponds to a registration request (challenge)
+                                  // https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Generate a url that uses should open to authenticate their github account
+    ///
+    /// This constructs a unique url per call, where each differs by the `state` parameter
+    pub async fn request_url() -> Option<String> {
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+        let gh_config = cfg.adapter.github.clone();
+        let base_url = gh_config.gh_url;
+        let client_id = gh_config.client_id;
+        let redirect_uri = gh_config
+            .redirect_url
+            // FIXME
+            .unwrap_or(url::Url::parse("https://rotko.net/").unwrap());
+
+        let url = url::Url::parse_with_params(
+            base_url.as_str(),
+            &[
+                ("client_id", client_id.as_str()),
+                ("redirect_uri", redirect_uri.as_str()),
+                ("state", &Token::generate().await.show()),
+                // `state` is a number corresponds to a registration request
+                // https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+            ],
+        )
+        .unwrap();
+        Some(url.to_string())
+    }
+
+    /// Get's github credentials to creates a [Github] instance
+    pub async fn new(params: &GithubRedirectSetp2Params) -> anyhow::Result<Self> {
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+        let gh_config = cfg.adapter.github.clone();
+
+        let client = Client::new();
+
+        let uri = url::Url::parse_with_params(
+            "https://github.com/login/oauth/access_token",
+            &[
+                ("client_id", gh_config.client_id.as_str()),
+                ("client_secret", gh_config.client_secret.as_str()),
+                ("code", params.code.as_str()),
+                // TODO: check if this is needed?
+                // ("redirect_uri", String::from("https://app.w3reg.org/").as_str()),
+            ],
+        )?;
+
+        let response = client
+            .get(uri)
+            .header(ACCEPT, "application/json")
+            .body("")
+            .send()
+            .await?;
+
+        let credentials = response.json::<GithubCred>().await?;
+
+        Ok(Self { cred: credentials })
+    }
+
+    /// Request username using provided credentials
+    pub async fn request_username(&self) -> anyhow::Result<String> {
+        let client = Client::new();
+        let uri = url::Url::parse("https://api.github.com/user")?;
+        let user = client
+            .get(uri)
+            .header("User-Agent", "W3R")
+            .bearer_auth(self.cred.access_token.as_str())
+            .send()
+            .await?;
+
+        let obj = serde_json::from_str::<serde_json::Value>(&user.text().await.unwrap_or_default())
+            .unwrap_or_default();
+
+        return Ok(obj["login"]
+            .as_str()
+            .unwrap_or_default()
+            .trim_matches('"')
+            .to_string());
+    }
+}
+
+/// Those params are added to the redirected url by github in setp 2, check this for more
+///
+/// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
+#[derive(Debug, Deserialize, Clone)]
+pub struct GithubRedirectSetp2Params {
+    pub code: String,
+    pub state: String,
+}
+
+/// Possible url params to an access token request, check this for more
+///
+/// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
+#[allow(unused)]
+#[derive(Debug, Deserialize, Clone)]
+pub struct GithubATRequestParams {
+    pub client_id: String,
+    pub client_secret: String,
+    pub code: String,
+    pub redirect_uri: Option<String>,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize, Clone)]
+pub struct GithubCred {
+    pub access_token: String,
+    pub scope: String,
+    pub token_type: String,
+}

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 pub mod dns;
 pub mod mail;
 pub mod matrix;
+pub mod github;
 
 pub trait Adapter {
     async fn handle_content(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,6 +13,7 @@ use url::Url;
 pub struct Adapter {
     pub matrix: MatrixConfig,
     pub email: EmailConfig,
+    pub github: GithubConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -20,6 +21,7 @@ pub struct Config {
     pub websocket: WebsocketConfig,
     pub registrar: RegistrarConfigs,
     pub redis: RedisConfig,
+    pub http: HTTPConfig,
     pub adapter: Adapter,
 }
 
@@ -170,5 +172,59 @@ impl WebsocketConfig {
             .to_socket_addrs()
             .unwrap()
             .next()
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GithubConfig {
+    /// github application token
+    pub client_id: String,
+    /// used in the first stage of oauth
+    pub gh_url: url::Url,
+    /// github client secret
+    pub client_secret: String,
+    /// url to redirect to when first stage is completed
+    pub redirect_url: Option<url::Url>,
+}
+
+impl Default for GithubConfig {
+    fn default() -> Self {
+        let gh_url = url::Url::parse_with_params(
+            "https://github.com/login/oauth/authorize",
+            &[("client_id", ""), ("redirect_uri", "")],
+        )
+        .unwrap();
+        let client_id = String::new();
+        let redirect_uri = None;
+        let client_secret = String::new();
+
+        Self {
+            gh_url,
+            client_id,
+            redirect_url: redirect_uri,
+            client_secret,
+        }
+    }
+}
+
+impl GithubConfig {}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct HTTPConfig {
+    pub host: String,
+    pub port: u16,
+    pub gh_endpoint: Option<String>,
+}
+
+impl Default for HTTPConfig {
+    fn default() -> Self {
+        let ip = String::from("0.0.0.0");
+        let port: u16 = 3000;
+        let gh_endpoint = None;
+        Self {
+            host: ip,
+            port,
+            gh_endpoint,
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod runner;
 mod token;
 
 use anyhow::{Context as _, Result};
+use api::spawn_http_serv;
 use std::panic;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
@@ -99,6 +100,7 @@ async fn main() -> Result<()> {
     runner.spawn(spawn_redis_subscriber, None).await;
     runner.spawn(spawn_node_listener, None).await;
     runner.spawn(spawn_ws_serv, None).await;
+    runner.spawn(spawn_http_serv, None).await;
 
     // check and start singleton services
     let (needs_email, needs_matrix_bot, needs_web) = check_required_services(&config).await;


### PR DESCRIPTION
- Implements an HTTP server/client to communicate with the Github server and create an OAuth request.
- Add config variables to control the HTTP server and Github application credentials.



@yassinebenarbia yeah i think we need redirect url to inform github to send user back to our frontend( i guess if we dont popup/modal/iframe it etc)