### PR TITLE
Feat: registration indexing, and expose a registrations search endpoing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5463,6 +5463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7983,6 +7993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8734,6 +8753,35 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.12.1",
+ "md-5",
+ "memchr",
+ "rand 0.9.0",
+ "sha2 0.10.8",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -12115,6 +12163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12673,6 +12732,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.0",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13075,6 +13160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13300,6 +13391,7 @@ dependencies = [
  "subxt",
  "subxt-signer",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "tokio-tungstenite",
  "toml 0.8.19",
@@ -13353,6 +13445,12 @@ checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -13791,6 +13889,17 @@ dependencies = [
  "sp-weights",
  "staging-xcm",
  "staging-xcm-builder",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ trust-dns-resolver = { version = "=0.23.2", features = ["dns-over-rustls"] }
 axum = "0.8.3"
 reqwest = { version = "0.12.15", features = ["json"] }
 sequoia-openpgp = {version = "2.0.0", default-features = false, features = ["compression", "crypto-openssl"]}
+tokio-postgres = "0.7.13"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/config.example.toml
+++ b/config.example.toml
@@ -25,9 +25,16 @@ port = 8080
 [redis]
 host = "0.0.0.0"
 port = 6379
-# leave them empty if you don't wish to an account
+# leave them empty if you don't have an account
 # username = "asdf"
 # password = "abc"
+
+[postgres]
+host = "0.0.0.0"
+port = 5432
+user = "tinker"
+# password = "asdf" Optional
+dbname = "name"
 
 [adapter]
 [adapter.matrix]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -250,7 +250,7 @@ pub struct PostgresConfig {
 
 impl Default for PostgresConfig {
     fn default() -> Self {
-        let user = env!("USER");
+        let user = std::env::var("USER").unwrap_or("root".into());
         Self {
             dbname: "postgres".to_string(),
             user: user.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,13 @@ mod adapter;
 mod api;
 mod config;
 mod node;
+mod postgres;
 mod runner;
 mod token;
 
 use anyhow::{Context as _, Result};
 use api::spawn_http_serv;
+use postgres::PostgresConnection;
 use std::panic;
 use tracing::{error, info, instrument};
 use tracing_subscriber::EnvFilter;
@@ -92,6 +94,12 @@ async fn main() -> Result<()> {
 
     // init redis conn pool
     RedisConnection::initialize_pool(&config.redis)?;
+
+    // init postgress table
+    PostgresConnection::new(&config.postgres)
+        .await?
+        .init_tables()
+        .await?;
 
     // initialize runner
     let mut runner = runner::Runner::new();

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,0 +1,491 @@
+use std::str::FromStr;
+// TODO: add stuff that registers what a user do, like someone requested this thing or that thing
+// etc
+// TODO: add table name for the queries?
+
+use subxt::utils::AccountId32;
+use tokio_postgres::{Client, NoTls};
+use tracing::info;
+
+use crate::{
+    api::{identity_data_tostring, Account, AccountType},
+    config::{PostgresConfig, GLOBAL_CONFIG},
+    node::{
+        self,
+        identity::events::JudgementGiven,
+        runtime_types::{
+            pallet_identity::types::Registration, people_paseo_runtime::people::IdentityInfo,
+        },
+        Client as NodeClient,
+    },
+};
+
+pub struct PostgresConnection {
+    client: Client,
+}
+
+impl PostgresConnection {
+    pub async fn init_tables(&mut self) -> anyhow::Result<()> {
+        info!("Creating `registration` table");
+        // TODO: parametarize table name?
+        let create_reg_record = "CREATE TABLE IF NOT EXISTS registration (
+            wallet_id       VARCHAR (48) PRIMARY KEY,
+            discord         TEXT,
+            twitter         TEXT,
+            matrix          TEXT,
+            email           TEXT,
+            display_name    TEXT,
+            github          TEXT,
+            legal           TEXT,
+            web             TEXT,
+            pgp_fingerprint VARCHAR (20)
+        )";
+        info!("QUERRY: {:?}", create_reg_record);
+        self.client.simple_query(create_reg_record).await?;
+
+        info!("Table `registration` created");
+        Ok(())
+    }
+
+    pub async fn write(&mut self, record: &Record) -> anyhow::Result<()> {
+        info!(who = ?record.wallet_id(), "Writing record");
+        let insert_reg_record =
+            "INSERT INTO registration (wallet_id, discord, twitter, matrix, email, display_name, github, legal, web, pgp_fingerprint)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ";
+        info!("QUERRY: {:?}", insert_reg_record);
+
+        self.client
+            .execute(
+                insert_reg_record,
+                &[
+                    &record.wallet_id(),
+                    &record.discord(),
+                    &record.twitter(),
+                    &record.matrix(),
+                    &record.email(),
+                    &record.display(),
+                    &record.github(),
+                    &record.legal(),
+                    &record.web(),
+                    &record.pgp_fingerprint(),
+                ],
+            )
+            .await?;
+        info!("Record written successfully");
+
+        Ok(())
+    }
+
+    pub async fn search<Q>(&mut self, search_querry: Q) -> anyhow::Result<Vec<Record>>
+    where
+        Q: Query,
+    {
+        Ok(self
+            .client
+            .simple_query(&search_querry.to_sql())
+            .await?
+            .iter()
+            .map(Record::from)
+            .collect())
+    }
+
+    pub async fn delete<Q>(&mut self, query: Q) -> anyhow::Result<()>
+    where
+        Q: Query,
+    {
+        self.client.simple_query(&query.to_sql()).await?;
+        Ok(())
+    }
+
+    pub async fn new(cfg: &PostgresConfig) -> anyhow::Result<Self> {
+        let mut conn_cfg = tokio_postgres::Config::new();
+        conn_cfg
+            .user(&cfg.user)
+            .host(&cfg.host)
+            .port(cfg.port)
+            .dbname(&cfg.dbname);
+        if let Some(pwd) = &cfg.password {
+            conn_cfg.password(pwd);
+        };
+        let (client, connection) = conn_cfg.connect(NoTls).await?;
+
+        let _join_handle = tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+        info!("New postgress connection established!");
+
+        Ok(Self { client })
+    }
+}
+
+#[derive(Debug)]
+pub struct Record {
+    wallet_id: AccountId32,
+    pub discord: Option<String>,
+    pub twitter: Option<String>,
+    pub matrix: Option<String>,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub github: Option<String>,
+    pub legal: Option<String>,
+    pub web: Option<String>,
+    pub pgp_fingerprint: Option<String>,
+}
+
+impl Record {
+    pub fn from_registration(
+        acc: &AccountId32,
+        registration: &Registration<u128, IdentityInfo>,
+    ) -> Self {
+        let pgp_fingerprint = match registration.info.pgp_fingerprint {
+            Some(bytes) => Some(hex::encode(bytes)),
+            None => None,
+        };
+        Self {
+            wallet_id: acc.to_owned(),
+            discord: identity_data_tostring(&registration.info.discord),
+            twitter: identity_data_tostring(&registration.info.twitter),
+            matrix: identity_data_tostring(&registration.info.matrix),
+            email: identity_data_tostring(&registration.info.email),
+            display_name: identity_data_tostring(&registration.info.display),
+            github: identity_data_tostring(&registration.info.github),
+            legal: identity_data_tostring(&registration.info.legal),
+            web: identity_data_tostring(&registration.info.web),
+            pgp_fingerprint,
+        }
+    }
+
+    // TODO: return None if judgement is not set correctly
+    pub async fn from_judgement(jud: &JudgementGiven) -> anyhow::Result<Option<Self>> {
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+
+        let reg_config = match cfg.registrar.registrar_config(jud.registrar_index) {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+
+        let client = NodeClient::from_url(&reg_config.endpoint).await?;
+        let registration = node::get_registration(&client, &jud.target).await?;
+        Ok(Some(Self::from_registration(&jud.target, &registration)))
+    }
+
+    pub fn wallet_id(&self) -> String {
+        self.wallet_id.to_owned().to_string()
+    }
+
+    pub fn discord(&self) -> String {
+        self.discord.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn twitter(&self) -> String {
+        self.twitter.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn matrix(&self) -> String {
+        self.matrix.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn email(&self) -> String {
+        self.email.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn display(&self) -> String {
+        self.display_name.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn github(&self) -> String {
+        self.github.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn legal(&self) -> String {
+        self.legal.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn web(&self) -> String {
+        self.web.to_owned().unwrap_or("NULL".to_string())
+    }
+
+    pub fn pgp_fingerprint(&self) -> String {
+        self.pgp_fingerprint
+            .to_owned()
+            .unwrap_or("NULL".to_string())
+    }
+
+    pub fn from(row: &tokio_postgres::SimpleQueryMessage) -> Self {
+        match row {
+            tokio_postgres::SimpleQueryMessage::Row(simple_query_row) => Self {
+                wallet_id: AccountId32::from_str(simple_query_row.get("wallet_id").unwrap())
+                    .unwrap(),
+                display_name: simple_query_row
+                    .get("display")
+                    .and_then(|v| Some(v.to_string())),
+                discord: simple_query_row
+                    .get("discord")
+                    .and_then(|v| Some(v.to_string())),
+                twitter: simple_query_row
+                    .get("twitter")
+                    .and_then(|v| Some(v.to_string())),
+                matrix: simple_query_row
+                    .get("matrix")
+                    .and_then(|v| Some(v.to_string())),
+                github: simple_query_row
+                    .get("github")
+                    .and_then(|v| Some(v.to_string())),
+                email: simple_query_row
+                    .get("email")
+                    .and_then(|v| Some(v.to_string())),
+                web: simple_query_row
+                    .get("web")
+                    .and_then(|v| Some(v.to_string())),
+                legal: simple_query_row
+                    .get("legal")
+                    .and_then(|v| Some(v.to_string())),
+                pgp_fingerprint: simple_query_row
+                    .get("pgp_fingerprint")
+                    .and_then(|v| Some(v.to_string())),
+            },
+            tokio_postgres::SimpleQueryMessage::CommandComplete(_) => unimplemented!(),
+            tokio_postgres::SimpleQueryMessage::RowDescription(arc) => unimplemented!(),
+            _ => todo!(),
+        }
+    }
+}
+
+pub trait Query {
+    fn to_sql(&self) -> String;
+}
+
+#[derive(Default)]
+struct SearchQuery {
+    displayed: Displayed,
+    condition: Option<Condition>,
+    table_name: String,
+}
+
+impl SearchQuery {
+    pub fn selected(mut self, displayed: Displayed) -> Self {
+        self.displayed = displayed;
+        self
+    }
+
+    pub fn condition(mut self, condition: Condition) -> Self {
+        self.condition = Some(condition);
+        self
+    }
+
+    pub fn table_name(mut self, dbname: String) -> Self {
+        self.table_name = dbname;
+        self
+    }
+}
+
+impl Query for SearchQuery {
+    fn to_sql(&self) -> String {
+        let mut querry = format!(
+            "SELECT {} FROM {}",
+            self.displayed.to_sql(),
+            self.table_name
+        );
+        match &self.condition {
+            Some(cond) => querry.push_str(&format!(" WHERE {}", cond.to_sql())),
+            None => {}
+        }
+        querry
+    }
+}
+
+#[derive(Default)]
+pub struct Condition {
+    querry: String,
+}
+
+// TODO: this api allows for .and().and() or .or().or() or even .account().account() which should
+// not happen, my thoughts is that this should be wrapped with a builder
+impl Condition {
+    pub fn and(mut self) -> Self {
+        self.querry.push_str("AND ");
+        self
+    }
+
+    pub fn or(mut self) -> Self {
+        self.querry.push_str("OR ");
+        self
+    }
+
+    pub fn account(mut self, account: &Account) -> Self {
+        let query = match account {
+            Account::Twitter(account) => format!("twitter='{}' ", account),
+            Account::Discord(account) => format!("discord='{}' ", account),
+            Account::Matrix(account) => format!("matrix='{}' ", account),
+            Account::Display(account) => format!("display='{}' ", account),
+            Account::Legal(account) => format!("legal='{}' ", account),
+            Account::Web(account) => format!("web='{}' ", account),
+            Account::Email(account) => format!("email='{}' ", account),
+            Account::Github(account) => format!("github='{}' ", account),
+            Account::PGPFingerprint(bytes) => {
+                format!(" pgp_fingerprint='{}' ", hex::encode(bytes))
+            }
+        };
+        self.querry.push_str(&query);
+        self
+    }
+
+    pub fn wallet_id(mut self, wallet_id: &AccountId32) -> Self {
+        self.querry.push_str(&wallet_id.to_string());
+        self
+    }
+}
+
+impl Query for Condition {
+    fn to_sql(&self) -> String {
+        if self.querry.is_empty() {
+            return "*".to_string();
+        } else {
+            self.querry
+                .trim_end_matches(|c| c == ' ' || c == ',')
+                .to_string()
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Displayed {
+    querry: String,
+}
+
+impl Displayed {
+    pub fn wallet_id(mut self) -> Self {
+        self.querry.push_str(&format!("wallet_id, "));
+        self
+    }
+
+    pub fn account(mut self, account: AccountType) -> Self {
+        let query = match account {
+            AccountType::Twitter => format!("twitter, "),
+            AccountType::Discord => format!("discord,  "),
+            AccountType::Matrix => format!("matrix, "),
+            AccountType::Display => format!("display, "),
+            AccountType::Legal => format!("legal, "),
+            AccountType::Web => format!("web, "),
+            AccountType::Email => format!("email, "),
+            AccountType::Github => format!("github, "),
+            AccountType::PGPFingerprint => format!("pgp_fingerprint, "),
+        };
+
+        self.querry.push_str(&query);
+        self
+    }
+}
+
+impl Query for Displayed {
+    fn to_sql(&self) -> String {
+        if self.querry.is_empty() {
+            return "*".to_string();
+        } else {
+            self.querry
+                .trim_end_matches(|c| c == ' ' || c == ',')
+                .to_string()
+        }
+    }
+}
+
+#[derive(Default)]
+struct DeleteQuery {
+    condition: Option<Condition>, // or Query in general
+    table_name: String,
+}
+
+impl DeleteQuery {
+    pub fn table_name(mut self, table_name: String) -> Self {
+        self.table_name = table_name;
+        self
+    }
+
+    pub fn condition(mut self, condition: Condition) -> Self {
+        self.condition = Some(condition);
+        self
+    }
+}
+
+impl Query for DeleteQuery {
+    fn to_sql(&self) -> String {
+        let mut query = format!("DELETE FROM {}", self.table_name);
+        if let Some(cond) = &self.condition {
+            query.push_str(&format!(" WHERE {}", cond.to_sql()));
+        };
+        query
+    }
+}
+
+impl Query for String {
+    fn to_sql(&self) -> String {
+        self.clone()
+    }
+}
+
+mod test {
+    use super::*;
+    #[test]
+    fn search_query_test() {
+        let condition = Condition::default()
+            .account(&Account::Matrix("matrix_acc".to_string()))
+            .and()
+            .account(&Account::Twitter("troll".to_string()))
+            .or()
+            .account(&Account::Matrix("anon".to_string()))
+            .and()
+            .account(&&Account::Web("example.com".to_string()));
+
+        let displayed = Displayed::default()
+            .wallet_id()
+            .account(AccountType::Email)
+            .account(AccountType::Discord);
+
+        let query = SearchQuery::default().table_name("registration".to_string());
+        assert_eq!(query.to_sql(), "SELECT * FROM registration");
+
+        let query = SearchQuery::default()
+            .table_name("registration".to_string())
+            .selected(displayed);
+        assert_eq!(
+            query.to_sql(),
+            "SELECT wallet_id, email, discord FROM registration"
+        );
+
+        let query = SearchQuery::default()
+            .table_name("registration".to_string())
+            .condition(condition);
+        assert_eq!(
+            query.to_sql(),
+            "SELECT * FROM registration WHERE matrix='matrix_acc' AND twitter='troll' OR matrix='anon' AND web='example.com'"
+        );
+    }
+
+    #[test]
+    fn delete_query_test() {
+        let table_name = "registration".to_string();
+        let condition = Condition::default()
+            .account(&Account::Matrix("matrix_acc".to_string()))
+            .and()
+            .account(&Account::Twitter("troll".to_string()))
+            .or()
+            .account(&Account::Matrix("anon".to_string()))
+            .and()
+            .account(&&Account::Web("example.com".to_string()));
+
+        let delete_query = DeleteQuery::default()
+            .table_name(table_name)
+            .condition(condition);
+        assert_eq!(
+            delete_query.to_sql(),
+            "DELETE FROM registration WHERE matrix='matrix_acc' AND twitter='troll' OR matrix='anon' AND web='example.com'"
+            );
+
+        let delete_query = DeleteQuery::default().table_name("registration".to_string());
+        assert_eq!(delete_query.to_sql(), "DELETE FROM registration");
+    }
+}

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,14 +1,15 @@
-use std::str::FromStr;
-// TODO: add stuff that registers what a user do, like someone requested this thing or that thing
-// etc
+#![allow(unused)]
 // TODO: add table name for the queries?
 
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use subxt::utils::AccountId32;
 use tokio_postgres::{Client, NoTls};
 use tracing::info;
 
 use crate::{
-    api::{identity_data_tostring, Account, AccountType},
+    api::{identity_data_tostring, AccountType, Filter, IncomingSearchRequest, Network},
     config::{PostgresConfig, GLOBAL_CONFIG},
     node::{
         self,
@@ -29,7 +30,8 @@ impl PostgresConnection {
         info!("Creating `registration` table");
         // TODO: parametarize table name?
         let create_reg_record = "CREATE TABLE IF NOT EXISTS registration (
-            wallet_id       VARCHAR (48) PRIMARY KEY,
+            wallet_id       VARCHAR (48),
+            network         TEXT,
             discord         TEXT,
             twitter         TEXT,
             matrix          TEXT,
@@ -38,9 +40,11 @@ impl PostgresConnection {
             github          TEXT,
             legal           TEXT,
             web             TEXT,
-            pgp_fingerprint VARCHAR (20)
+            pgp_fingerprint VARCHAR (20),
+            PRIMARY KEY (wallet_id, network)
         )";
-        info!("QUERRY: {:?}", create_reg_record);
+        info!("QUERRY");
+        info!("{create_reg_record}");
         self.client.simple_query(create_reg_record).await?;
 
         info!("Table `registration` created");
@@ -52,7 +56,7 @@ impl PostgresConnection {
         let insert_reg_record =
             "INSERT INTO registration (wallet_id, discord, twitter, matrix, email, display_name, github, legal, web, pgp_fingerprint)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ";
-        info!("QUERRY: {:?}", insert_reg_record);
+        info!(query=?insert_reg_record,"QUERRY");
 
         self.client
             .execute(
@@ -82,7 +86,7 @@ impl PostgresConnection {
     {
         Ok(self
             .client
-            .simple_query(&search_querry.to_sql())
+            .query(&search_querry.to_sql(), &[])
             .await?
             .iter()
             .map(Record::from)
@@ -118,19 +122,44 @@ impl PostgresConnection {
 
         Ok(Self { client })
     }
+
+    pub async fn default() -> anyhow::Result<Self> {
+        let cfg = GLOBAL_CONFIG.get().unwrap();
+        let pog_config = cfg.postgres.clone();
+        PostgresConnection::new(&pog_config).await
+    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Record {
-    wallet_id: AccountId32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wallet_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub discord: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub twitter: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub github: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub legal: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub web: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pgp_fingerprint: Option<String>,
 }
 
@@ -144,7 +173,7 @@ impl Record {
             None => None,
         };
         Self {
-            wallet_id: acc.to_owned(),
+            wallet_id: Some(acc.to_string()),
             discord: identity_data_tostring(&registration.info.discord),
             twitter: identity_data_tostring(&registration.info.twitter),
             matrix: identity_data_tostring(&registration.info.matrix),
@@ -174,7 +203,7 @@ impl Record {
     }
 
     pub fn wallet_id(&self) -> String {
-        self.wallet_id.to_owned().to_string()
+        self.discord.to_owned().unwrap_or("NULL".to_string())
     }
 
     pub fn discord(&self) -> String {
@@ -214,44 +243,36 @@ impl Record {
             .to_owned()
             .unwrap_or("NULL".to_string())
     }
+}
 
-    pub fn from(row: &tokio_postgres::SimpleQueryMessage) -> Self {
-        match row {
-            tokio_postgres::SimpleQueryMessage::Row(simple_query_row) => Self {
-                wallet_id: AccountId32::from_str(simple_query_row.get("wallet_id").unwrap())
-                    .unwrap(),
-                display_name: simple_query_row
-                    .get("display")
-                    .and_then(|v| Some(v.to_string())),
-                discord: simple_query_row
-                    .get("discord")
-                    .and_then(|v| Some(v.to_string())),
-                twitter: simple_query_row
-                    .get("twitter")
-                    .and_then(|v| Some(v.to_string())),
-                matrix: simple_query_row
-                    .get("matrix")
-                    .and_then(|v| Some(v.to_string())),
-                github: simple_query_row
-                    .get("github")
-                    .and_then(|v| Some(v.to_string())),
-                email: simple_query_row
-                    .get("email")
-                    .and_then(|v| Some(v.to_string())),
-                web: simple_query_row
-                    .get("web")
-                    .and_then(|v| Some(v.to_string())),
-                legal: simple_query_row
-                    .get("legal")
-                    .and_then(|v| Some(v.to_string())),
-                pgp_fingerprint: simple_query_row
-                    .get("pgp_fingerprint")
-                    .and_then(|v| Some(v.to_string())),
-            },
-            tokio_postgres::SimpleQueryMessage::CommandComplete(_) => unimplemented!(),
-            tokio_postgres::SimpleQueryMessage::RowDescription(arc) => unimplemented!(),
-            _ => todo!(),
+impl From<&tokio_postgres::Row> for Record {
+    fn from(value: &tokio_postgres::Row) -> Self {
+        let mut record = Record::default();
+        let displayed_info: Vec<DisplayedInfo> = value
+            .columns()
+            .iter()
+            .map(|v| DisplayedInfo::from_str(v.name()))
+            .filter_map(|v| v.ok())
+            .collect();
+
+        for info in displayed_info {
+            match info {
+                DisplayedInfo::WalletID => record.wallet_id = value.get("wallet_id"),
+                DisplayedInfo::Discord => record.discord = value.get("discord"),
+                DisplayedInfo::Display => record.display_name = value.get("display"),
+                DisplayedInfo::Email => record.email = value.get("email"),
+                DisplayedInfo::Matrix => record.matrix = value.get("matrix"),
+                DisplayedInfo::Twitter => record.twitter = value.get("twitter"),
+                DisplayedInfo::Github => record.github = value.get("github"),
+                DisplayedInfo::Legal => record.legal = value.get("legal"),
+                DisplayedInfo::Web => record.web = value.get("web"),
+                DisplayedInfo::PGPFingerprint => {
+                    record.pgp_fingerprint = value.get("pgp_fingerprint")
+                }
+            }
         }
+
+        return record;
     }
 }
 
@@ -260,7 +281,7 @@ pub trait Query {
 }
 
 #[derive(Default)]
-struct SearchQuery {
+pub struct SearchQuery {
     displayed: Displayed,
     condition: Option<Condition>,
     table_name: String,
@@ -290,15 +311,18 @@ impl Query for SearchQuery {
             self.displayed.to_sql(),
             self.table_name
         );
-        match &self.condition {
-            Some(cond) => querry.push_str(&format!(" WHERE {}", cond.to_sql())),
-            None => {}
-        }
+
+        let cond = match &self.condition {
+            Some(cond) => &format!(" {}", cond.to_sql()),
+            None => "",
+        };
+        querry.push_str(cond.trim_end());
+
         querry
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Condition {
     querry: String,
 }
@@ -316,21 +340,46 @@ impl Condition {
         self
     }
 
-    pub fn account(mut self, account: &Account) -> Self {
+    pub fn like_condition(mut self, account: &SearchInfo) -> Self {
         let query = match account {
-            Account::Twitter(account) => format!("twitter='{}' ", account),
-            Account::Discord(account) => format!("discord='{}' ", account),
-            Account::Matrix(account) => format!("matrix='{}' ", account),
-            Account::Display(account) => format!("display='{}' ", account),
-            Account::Legal(account) => format!("legal='{}' ", account),
-            Account::Web(account) => format!("web='{}' ", account),
-            Account::Email(account) => format!("email='{}' ", account),
-            Account::Github(account) => format!("github='{}' ", account),
-            Account::PGPFingerprint(bytes) => {
+            SearchInfo::AccountId32(info) => format!("wallet_id LIKE '%{}%' ", info),
+            SearchInfo::Twitter(account) => format!("twitter LIKE '%{}%' ", account),
+            SearchInfo::Discord(account) => format!("discord LIKE '%{}%' ", account),
+            SearchInfo::Matrix(account) => format!("matrix LIKE '%{}%' ", account),
+            SearchInfo::Display(account) => format!("display LIKE '%{}%' ", account),
+            SearchInfo::Legal(account) => format!("legal LIKE '%{}%' ", account),
+            SearchInfo::Web(account) => format!("web LIKE '%{}%' ", account),
+            SearchInfo::Email(account) => format!("email LIKE '%{}%' ", account),
+            SearchInfo::Github(account) => format!("github LIKE '%{}%' ", account),
+            SearchInfo::PGPFingerprint(bytes) => {
+                format!(" pgp_fingerprint LIKE '%{}%' ", hex::encode(bytes))
+            }
+        };
+        self.querry.push_str(&query);
+        self
+    }
+
+    pub fn condition(mut self, info: &SearchInfo) -> Self {
+        let query = match info {
+            SearchInfo::AccountId32(info) => format!("wallet_id='{}' ", info),
+            SearchInfo::Twitter(account) => format!("twitter='{}' ", account),
+            SearchInfo::Discord(account) => format!("discord='{}' ", account),
+            SearchInfo::Matrix(account) => format!("matrix='{}' ", account),
+            SearchInfo::Display(account) => format!("display='{}' ", account),
+            SearchInfo::Legal(account) => format!("legal='{}' ", account),
+            SearchInfo::Web(account) => format!("web='{}' ", account),
+            SearchInfo::Email(account) => format!("email='{}' ", account),
+            SearchInfo::Github(account) => format!("github='{}' ", account),
+            SearchInfo::PGPFingerprint(bytes) => {
                 format!(" pgp_fingerprint='{}' ", hex::encode(bytes))
             }
         };
         self.querry.push_str(&query);
+        self
+    }
+
+    pub fn network(mut self, network: &Network) -> Self {
+        self.querry.push_str(&format!("network='{}' ", network));
         self
     }
 
@@ -340,14 +389,29 @@ impl Condition {
     }
 }
 
+impl FromStr for Condition {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            querry: s.to_owned(),
+        })
+    }
+}
+
 impl Query for Condition {
     fn to_sql(&self) -> String {
         if self.querry.is_empty() {
-            return "*".to_string();
+            return String::new();
         } else {
-            self.querry
-                .trim_end_matches(|c| c == ' ' || c == ',')
-                .to_string()
+            format!(
+                "WHERE {}",
+                self.querry.trim_end_matches(|c| c == ' '
+                    || c == ','
+                    || c == 'A'
+                    || c == 'N'
+                    || c == 'D')
+            )
         }
     }
 }
@@ -366,9 +430,9 @@ impl Displayed {
     pub fn account(mut self, account: AccountType) -> Self {
         let query = match account {
             AccountType::Twitter => format!("twitter, "),
-            AccountType::Discord => format!("discord,  "),
+            AccountType::Discord => format!("discord, "),
             AccountType::Matrix => format!("matrix, "),
-            AccountType::Display => format!("display, "),
+            AccountType::Display => format!("display_name, "),
             AccountType::Legal => format!("legal, "),
             AccountType::Web => format!("web, "),
             AccountType::Email => format!("email, "),
@@ -415,7 +479,7 @@ impl Query for DeleteQuery {
     fn to_sql(&self) -> String {
         let mut query = format!("DELETE FROM {}", self.table_name);
         if let Some(cond) = &self.condition {
-            query.push_str(&format!(" WHERE {}", cond.to_sql()));
+            query.push_str(&format!(" {}", cond.to_sql()));
         };
         query
     }
@@ -427,30 +491,104 @@ impl Query for String {
     }
 }
 
+// TODO: add network for the displayed info
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash)]
+pub enum DisplayedInfo {
+    WalletID,
+    Discord,
+    Display,
+    Email,
+    Matrix,
+    Twitter,
+    Github,
+    Legal,
+    Web,
+    PGPFingerprint,
+}
+
+impl DisplayedInfo {
+    #[allow(unused)]
+    fn all_values() -> String {
+        let v = vec![
+            Self::WalletID,
+            Self::Discord,
+            Self::Display,
+            Self::Email,
+            Self::Matrix,
+            Self::Twitter,
+            Self::Github,
+            Self::Legal,
+            Self::Web,
+            Self::PGPFingerprint,
+        ];
+        format!("{v:?}")
+    }
+}
+
+impl FromStr for DisplayedInfo {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "wallet_id" | "WalletID" | "Wallet_ID" | "walletId" => return Ok(Self::WalletID),
+            "Discord" | "discord" => return Ok(Self::Discord),
+            "Display" | "display" => return Ok(Self::Display),
+            "Email" | "email" => return Ok(Self::Email),
+            "Matrix" | "matrix" => return Ok(Self::Matrix),
+            "Twitter" | "twitter" => return Ok(Self::Twitter),
+            "Github" | "github" => return Ok(Self::Github),
+            "Legal" | "legal" => return Ok(Self::Legal),
+            "Web" | "web" => return Ok(Self::Web),
+            "PGPFingerprint" | "pgpfingerprint" | "pgp_fingerprint" | "PGP_Fingerprint" => {
+                return Ok(Self::PGPFingerprint)
+            }
+            _ => return Err(anyhow!("Unknown type {s}")),
+        }
+    }
+}
+
+// TODO: switch to str instead of String :)
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SearchInfo {
+    AccountId32(String),
+    Twitter(String),
+    Discord(String),
+    Matrix(String),
+    Display(String),
+    Legal(String),
+    Web(String),
+    Email(String),
+    Github(String),
+    PGPFingerprint([u8; 20]),
+}
+
 mod test {
+    #[allow(unused_imports)]
     use super::*;
+
     #[test]
     fn search_query_test() {
         let condition = Condition::default()
-            .account(&Account::Matrix("matrix_acc".to_string()))
+            .condition(&SearchInfo::Matrix("matrix_acc".to_string()))
             .and()
-            .account(&Account::Twitter("troll".to_string()))
+            .condition(&SearchInfo::Twitter("troll".to_string()))
             .or()
-            .account(&Account::Matrix("anon".to_string()))
+            .condition(&SearchInfo::Matrix("anon".to_string()))
             .and()
-            .account(&&Account::Web("example.com".to_string()));
+            .condition(&SearchInfo::Web("example.com".to_string()));
+
+        let query = SearchQuery::default().table_name("registration".to_string());
+        assert_eq!(query.to_sql(), "SELECT * FROM registration");
 
         let displayed = Displayed::default()
             .wallet_id()
             .account(AccountType::Email)
             .account(AccountType::Discord);
 
-        let query = SearchQuery::default().table_name("registration".to_string());
-        assert_eq!(query.to_sql(), "SELECT * FROM registration");
-
         let query = SearchQuery::default()
             .table_name("registration".to_string())
             .selected(displayed);
+
         assert_eq!(
             query.to_sql(),
             "SELECT wallet_id, email, discord FROM registration"
@@ -469,13 +607,13 @@ mod test {
     fn delete_query_test() {
         let table_name = "registration".to_string();
         let condition = Condition::default()
-            .account(&Account::Matrix("matrix_acc".to_string()))
+            .condition(&SearchInfo::Matrix("matrix_acc".to_string()))
             .and()
-            .account(&Account::Twitter("troll".to_string()))
+            .condition(&SearchInfo::Twitter("troll".to_string()))
             .or()
-            .account(&Account::Matrix("anon".to_string()))
+            .condition(&SearchInfo::Matrix("anon".to_string()))
             .and()
-            .account(&&Account::Web("example.com".to_string()));
+            .condition(&SearchInfo::Web("example.com".to_string()));
 
         let delete_query = DeleteQuery::default()
             .table_name(table_name)
@@ -487,5 +625,102 @@ mod test {
 
         let delete_query = DeleteQuery::default().table_name("registration".to_string());
         assert_eq!(delete_query.to_sql(), "DELETE FROM registration");
+    }
+
+    #[test]
+    fn query_condition() {
+        let condition = Condition::default()
+            .condition(&SearchInfo::Matrix("matrix_acc".to_string()))
+            .and()
+            .condition(&SearchInfo::Twitter("troll".to_string()))
+            .or()
+            .condition(&SearchInfo::Matrix("anon".to_string()))
+            .and()
+            .condition(&SearchInfo::Web("example.com".to_string()))
+            .and();
+
+        assert_eq!(
+            condition.to_sql(),
+            "WHERE matrix='matrix_acc' AND twitter='troll' OR matrix='anon' AND web='example.com'"
+        );
+
+        let condition = Condition::default()
+            .like_condition(&SearchInfo::Matrix("matrix_acc".to_string()))
+            .and()
+            .like_condition(&SearchInfo::Twitter("troll".to_string()))
+            .or()
+            .like_condition(&SearchInfo::Matrix("anon".to_string()))
+            .and()
+            .like_condition(&SearchInfo::Web("example.com".to_string()))
+            .and();
+
+        assert_eq!(
+            condition.to_sql(),
+            "WHERE matrix LIKE '%matrix_acc%' AND twitter LIKE '%troll%' OR matrix LIKE '%anon%' AND web LIKE '%example.com%'"
+        );
+
+        let condition = Condition::default();
+
+        assert_eq!(condition.to_sql(), String::new());
+
+        let condition = Condition::default()
+            .network(&Network::Paseo)
+            .or()
+            .network(&Network::Polkadot)
+            .and()
+            .condition(&SearchInfo::Twitter("troll".to_string()));
+
+        assert_eq!(
+            condition.to_sql(),
+            "WHERE network='paseo' OR network='polkadot' AND twitter='troll'"
+        );
+    }
+
+    #[test]
+    fn from_search_request() {
+        let network: Option<Network> = Some(Network::Rococo);
+        let outputs: Vec<DisplayedInfo> = vec![DisplayedInfo::WalletID, DisplayedInfo::Display];
+        let filters: Vec<Filter> = vec![Filter::new(
+            SearchInfo::Display("Travis Hernandez".to_string()),
+            true,
+        )];
+
+        let search_req = IncomingSearchRequest::new(network, outputs.clone(), filters.clone());
+        let search_query: SearchQuery = search_req.into();
+
+        assert_eq!(
+            search_query.to_sql(),
+            "SELECT wallet_id, display_name FROM registration WHERE network='rococo' AND display='Travis Hernandez'"
+        );
+        //  ------------------------------------------------------------------------------
+        let network: Option<Network> = None;
+
+        let search_req =
+            IncomingSearchRequest::new(network.clone(), outputs.clone(), filters.clone());
+        let search_query: SearchQuery = search_req.into();
+
+        assert_eq!(
+            search_query.to_sql(),
+            "SELECT wallet_id, display_name FROM registration WHERE display='Travis Hernandez'"
+        );
+        //  ------------------------------------------------------------------------------
+        let outputs: Vec<DisplayedInfo> = vec![];
+        let search_req =
+            IncomingSearchRequest::new(network.clone(), outputs.clone(), filters.clone());
+
+        let search_query: SearchQuery = search_req.into();
+
+        assert_eq!(
+            search_query.to_sql(),
+            "SELECT * FROM registration WHERE display='Travis Hernandez'"
+        );
+        //  ------------------------------------------------------------------------------
+        let filters: Vec<Filter> = vec![];
+        let search_req =
+            IncomingSearchRequest::new(network.clone(), outputs.clone(), filters.clone());
+
+        let search_query: SearchQuery = search_req.into();
+
+        assert_eq!(search_query.to_sql(), "SELECT * FROM registration");
     }
 }


### PR DESCRIPTION
# Changes:

- **TYPO FIXES :D**
- Save successful registrations (verified by us) in a long term Postgres DB
- New WS endpoint for searching successful registrations (by us) (needs more documentation about what fields are accepted)
- New configuration fields for the Postgres DB https://github.com/rotkonetworks/w3registrar/blob/8d3634d6c024bb50ce85049cfc8564864eb85a05/config.example.toml#L32-L37
- Internal interface to create search requests (for convenience)
- **MORE TODOs**