### PR TITLE
Refactor: minor changes (kinda)

### DIFF
--- a/src/adapter/github.rs
+++ b/src/adapter/github.rs
@@ -45,9 +45,12 @@ impl Github {
     }
 
     /// Validates that the state parameter is a valid token
-    pub async fn validate_state(state: &str) -> anyhow::Result<()> {
+    ///
+    /// Checks state has invalid length (8) since the state url param is a `An unguessable random string.`
+    /// [source](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity)
+    pub async fn validate_state_length(state: &str) -> anyhow::Result<()> {
         // TODO: check against stored state tokens
-        if state.is_empty() {
+        if state.len() != 8 {
             return Err(anyhow!("Invalid state parameter"));
         }
         Ok(())
@@ -83,7 +86,16 @@ impl Github {
     }
 
     /// Gets github credentials to creates a [Github] instance
+    ///
+    /// # Errors
+    ///
+    /// - `params.state` is empty or has invalid length (8)
+    /// - Failed to send http request to the Github API.
+    /// - Fails to deserialize Github http response to [GithubCred]
     pub async fn new(params: &GithubRedirectStepTwoParams) -> anyhow::Result<Self> {
+        // Validate state parameter first
+        Github::validate_state_length(&params.state).await?;
+
         let cfg = GLOBAL_CONFIG
             .get()
             .expect("GLOBAL_CONFIG is not initialized");
@@ -138,10 +150,12 @@ impl Github {
 
 /// Those params are added to the redirected url by github in step 2, check this for more
 ///
-/// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
+/// [Resource](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github)
 #[derive(Debug, Deserialize, Clone)]
 pub struct GithubRedirectStepTwoParams {
+    /// Temporarily Constructed by Github to finish step 2 in OAuth
     pub code: String,
+    /// Constructed by w3r to uniquely identify a Github OAuth request
     pub state: String,
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -2149,11 +2149,6 @@ fn log_error_and_return(log: String) -> String {
 async fn github_oauth_callback(Query(params): Query<GithubRedirectStepTwoParams>) -> String {
     info!(params=?params, "PARAMS");
 
-    // Validate state parameter first
-    if let Err(e) = Github::validate_state(&params.state).await {
-        return log_error_and_return(format!("State validation failed: {e}"));
-    }
-
     // github instance to request acc info
     let gh = match Github::new(&params).await {
         Ok(gh) => gh,


### PR DESCRIPTION
# Changes:

- HTTP param check, specifically the `state` param, is now a check against it's length (8) and under the `Github::new` constructor https://github.com/rotkonetworks/w3registrar/commit/47f302439b754580ca0196c6b0cd1b8f5bbac34e
- Possible WS messages are now represented as an enum named `WebSocketMessage` https://github.com/rotkonetworks/w3registrar/commit/509edfb71c0f0b1ff67a09679dac6cd6d81ccb9f
- Other minor fixes