### PR TITLE
feat: index old registrations in postgres DB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4"] }
 postgres-openssl = "0.5.1"
 openssl = "0.10.73"
 postgres-types = { version = "0.2.9", features = ["derive"] }
+jsonrpsee = { version = "0.24.9", features = ["client", "ws-client"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,87 +1,200 @@
 use jsonrpsee::{core::client::ClientT, ws_client::WsClientBuilder};
 use sp_core::H256;
-use tracing::info;
+use tracing::{error, info, info_span, instrument, Span};
 
 use crate::{
     api::Network,
     config::GLOBAL_CONFIG,
-    node::{identity::events::JudgementGiven, Client as NodeClient},
+    node::{
+        get_judgement, identity::events::JudgementGiven,
+        runtime_types::pallet_identity::types::Judgement, Client as NodeClient,
+    },
     postgres::{IndexerState, PostgresConnection, RegistrationRecord},
 };
 
-pub async fn index_identities_on_chain(state: IndexerState) -> anyhow::Result<()> {
-    let network = state.network;
-    let index = state.last_block_index;
-    navigate_identity_chain_from_block(index, network).await?;
-    Ok(())
+#[derive(Clone)]
+pub struct Indexer {
+    span: Span,
 }
 
-async fn navigate_identity_chain_from_block(
-    start_block_index: i64,
-    network: Network,
-) -> anyhow::Result<()> {
-    let cfg = GLOBAL_CONFIG
-        .get()
-        .expect("GLOBAL_CONFIG is not initialized");
+impl Indexer {
+    pub async fn new() -> anyhow::Result<Self> {
+        let span = info_span!("node_listener");
 
-    let network_cfg = cfg
-        .registrar
-        .get_network(&network)
-        .ok_or_else(|| anyhow::anyhow!("Network {} not configured", network))
-        .unwrap();
+        Ok(Self { span })
+    }
 
-    let client = NodeClient::from_url(&network_cfg.endpoint).await?;
-    let current_block_index = client.blocks().at_latest().await?.number() as i64;
+    #[instrument(skip_all, parent = &self.span)]
+    async fn index_identities(self, network: &Network) -> anyhow::Result<()> {
+        let pog_connection = PostgresConnection::default().await?;
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+        match pog_connection.get_indexer_state(network).await {
+            Ok(state) => {
+                let network_cfg = cfg
+                    .registrar
+                    .get_network(&network)
+                    .ok_or_else(|| anyhow::anyhow!("Network {} not configured", network))
+                    .unwrap();
 
-    let ws_client = WsClientBuilder::default()
-        .build(&network_cfg.endpoint)
-        .await
-        .unwrap();
+                let client = NodeClient::from_url(&network_cfg.endpoint).await?;
 
-    let mut pog_connection = PostgresConnection::default().await?;
+                let block_index = client.blocks().at_latest().await?.number();
+                let block_hash = client.blocks().at_latest().await?.hash();
 
-    for block_index in start_block_index..current_block_index {
-        let block_hash: H256 = ws_client
-            .request::<Option<H256>, _>("chain_getBlockHash", [block_index])
-            .await
-            .unwrap()
+                if state.last_block_index.ne(&(block_index as i64))
+                    || state.last_block_hash.ne(&block_hash)
+                {
+                    info!(start_block_index=?block_index, end_block_index=?state.last_block_index, "Filling missing blocks");
+                    self.index_remaining_identities(state).await?;
+                }
+            }
+            Err(e) => {
+                error!(error=?e,"ERROR");
+                info!("Indexing all identities from the First block");
+                self.index_identities_from_start(&network).await?;
+            }
+        }
+        info!(network = ?network, "Finished indexing network");
+
+        Ok(())
+    }
+
+    #[instrument(skip_all, parent = &self.span)]
+    async fn index_remaining_identities(&self, state: IndexerState) -> anyhow::Result<()> {
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+
+        let network_cfg = cfg
+            .registrar
+            .get_network(&state.network)
+            .ok_or_else(|| anyhow::anyhow!("Network {} not configured", state.network))
             .unwrap();
 
-        match client.blocks().at(block_hash).await {
-            Ok(block) => {
-                if block_index % 50 == 0 {
-                    info!(hash=?block_hash.to_string(), number=?block_index,"Block");
-                }
+        let client = NodeClient::from_url(&network_cfg.endpoint).await?;
 
-                if let Ok(events) = block.events().await {
-                    for event in events.iter() {
-                        if let Ok(event) = event {
-                            if let Ok(Some(event)) = event.as_event::<JudgementGiven>() {
-                                if let Some(record) =
-                                    RegistrationRecord::from_judgement(&event).await.unwrap()
-                                {
-                                    pog_connection
-                                        .save_registration(&record, &block_hash, &block_index)
-                                        .await
-                                        .unwrap();
+        let current_block_index: i64 = client.blocks().at_latest().await?.number() as i64;
+
+        let ws_client = WsClientBuilder::default()
+            .build(&network_cfg.endpoint)
+            .await
+            .unwrap();
+
+        let mut pog_connection = PostgresConnection::default().await?;
+
+        for block_index in state.last_block_index..current_block_index {
+            let block_hash: H256 = ws_client
+                .request::<Option<H256>, _>("chain_getBlockHash", [block_index])
+                .await
+                .unwrap()
+                .unwrap();
+
+            match client.blocks().at(block_hash).await {
+                Ok(block) => {
+                    if block_index % 100 == 0 {
+                        info!(hash=?block_hash.to_string(), number=?block_index,"Block");
+                    }
+
+                    // TODO: deal with ever ending nesting...
+                    if let Ok(events) = block.events().await {
+                        for event in events.iter() {
+                            if let Ok(event) = event {
+                                if let Ok(Some(jud)) = event.as_event::<JudgementGiven>() {
+                                    if let Ok(Some(judgement)) =
+                                        get_judgement(&jud.target, &state.network).await
+                                    {
+                                        if matches!(judgement, Judgement::Reasonable) {
+                                            if let Some(record) =
+                                                RegistrationRecord::from_judgement(&jud)
+                                                    .await
+                                                    .unwrap()
+                                            {
+                                                pog_connection
+                                                    .save_registration(&record)
+                                                    .await
+                                                    .unwrap();
+                                                info!(registrar_index=?jud.registrar_index, wallet_id=?jud.target,"`JudgementGiven` Event");
+                                            }
+                                        }
+                                    }
                                 }
-
-                                info!(registrar_index=?event.registrar_index, wallet_id=?event.target,"Event");
                             }
                         }
                     }
                 }
+                Err(e) => {
+                    println!("Failed to get block #{}: {}", block_hash, e);
+                }
             }
-            Err(e) => {
-                println!("Failed to get block #{}: {}", block_hash, e);
+        }
+        Ok(())
+    }
+
+    #[instrument(skip_all, parent = &self.span)]
+    async fn index_identities_from_start(&self, network: &Network) -> anyhow::Result<()> {
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+
+        let network_cfg = cfg
+            .registrar
+            .get_network(&network)
+            .ok_or_else(|| anyhow::anyhow!("Network {} not configured", network))
+            .unwrap();
+
+        let client = NodeClient::from_url(&network_cfg.endpoint).await?;
+
+        let mut pog_connection = PostgresConnection::default().await?;
+
+        let block_index = client.blocks().at_latest().await?.number();
+        let block_hash = client.blocks().at_latest().await?.hash();
+
+        let mut iter = client
+            .storage()
+            .at_latest()
+            .await?
+            .iter(super::node::storage().identity().identity_of_iter())
+            .await?;
+
+        // TODO: buffer every 50 or so request and then execute that at a one go, instead of
+        // running one request at a time?
+        while let Some(Ok(identity)) = &iter.next().await {
+            if let Some(record) = RegistrationRecord::from_storage_pairs(&identity, &network)
+                .await
+                .unwrap()
+            {
+                pog_connection.save_registration(&record).await?;
             }
         }
 
-        if block_index % 50 == 0 {
-            pog_connection
-                .update_indexer_state(&network, &block_hash, &(block_index as i64))
-                .await?;
-        }
+        pog_connection
+            .update_indexer_state(&network, &block_hash, &(block_index as i64))
+            .await?;
+
+        Ok(())
     }
-    Ok(())
+
+    #[instrument(skip_all, parent = &self.span)]
+    pub async fn index(self) -> anyhow::Result<()> {
+        info!("Starting indexer");
+
+        let cfg = GLOBAL_CONFIG
+            .get()
+            .expect("GLOBAL_CONFIG is not initialized");
+        let networks = cfg.registrar.supported_networks();
+
+        for network in networks {
+            let clone = self.clone();
+            tokio::spawn(async move {
+                match clone.index_identities(&network).await {
+                    Ok(_) => {}
+                    Err(e) => error!(network=?network, error=?e, "Failed to index identities"),
+                }
+            });
+        }
+
+        Ok(())
+    }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,0 +1,87 @@
+use jsonrpsee::{core::client::ClientT, ws_client::WsClientBuilder};
+use sp_core::H256;
+use tracing::info;
+
+use crate::{
+    api::Network,
+    config::GLOBAL_CONFIG,
+    node::{identity::events::JudgementGiven, Client as NodeClient},
+    postgres::{IndexerState, PostgresConnection, RegistrationRecord},
+};
+
+pub async fn index_identities_on_chain(state: IndexerState) -> anyhow::Result<()> {
+    let network = state.network;
+    let index = state.last_block_index;
+    navigate_identity_chain_from_block(index, network).await?;
+    Ok(())
+}
+
+async fn navigate_identity_chain_from_block(
+    start_block_index: i64,
+    network: Network,
+) -> anyhow::Result<()> {
+    let cfg = GLOBAL_CONFIG
+        .get()
+        .expect("GLOBAL_CONFIG is not initialized");
+
+    let network_cfg = cfg
+        .registrar
+        .get_network(&network)
+        .ok_or_else(|| anyhow::anyhow!("Network {} not configured", network))
+        .unwrap();
+
+    let client = NodeClient::from_url(&network_cfg.endpoint).await?;
+    let current_block_index = client.blocks().at_latest().await?.number() as i64;
+
+    let ws_client = WsClientBuilder::default()
+        .build(&network_cfg.endpoint)
+        .await
+        .unwrap();
+
+    let mut pog_connection = PostgresConnection::default().await?;
+
+    for block_index in start_block_index..current_block_index {
+        let block_hash: H256 = ws_client
+            .request::<Option<H256>, _>("chain_getBlockHash", [block_index])
+            .await
+            .unwrap()
+            .unwrap();
+
+        match client.blocks().at(block_hash).await {
+            Ok(block) => {
+                if block_index % 50 == 0 {
+                    info!(hash=?block_hash.to_string(), number=?block_index,"Block");
+                }
+
+                if let Ok(events) = block.events().await {
+                    for event in events.iter() {
+                        if let Ok(event) = event {
+                            if let Ok(Some(event)) = event.as_event::<JudgementGiven>() {
+                                if let Some(record) =
+                                    RegistrationRecord::from_judgement(&event).await.unwrap()
+                                {
+                                    pog_connection
+                                        .save_registration(&record, &block_hash, &block_index)
+                                        .await
+                                        .unwrap();
+                                }
+
+                                info!(registrar_index=?event.registrar_index, wallet_id=?event.target,"Event");
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                println!("Failed to get block #{}: {}", block_hash, e);
+            }
+        }
+
+        if block_index % 50 == 0 {
+            pog_connection
+                .update_indexer_state(&network, &block_hash, &(block_index as i64))
+                .await?;
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,10 @@ mod node;
 mod postgres;
 mod runner;
 mod token;
+mod indexer;
 
 use anyhow::{Context as _, Result};
-use api::spawn_http_serv;
+use api::{spawn_http_serv, spawn_identity_indexer};
 use postgres::PostgresConnection;
 use std::panic;
 use tracing::{error, info, instrument};
@@ -111,6 +112,7 @@ async fn main() -> Result<()> {
     runner.spawn(spawn_node_listener, None).await;
     runner.spawn(spawn_ws_serv, None).await;
     runner.spawn(spawn_http_serv, None).await;
+    runner.spawn(spawn_identity_indexer, None).await;
 
     // check and start singleton services
     let (needs_email, needs_matrix_bot, needs_web) = check_required_services(&config).await;

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -236,9 +236,21 @@ $$;";
 
     pub async fn save_registration(&mut self, record: &RegistrationRecord) -> anyhow::Result<()> {
         info!(who = ?record.wallet_id(), "Writing record");
-        let insert_reg_record =
-            format!("INSERT INTO registration(wallet_id, discord, twitter, matrix, email, display_name, github, legal, web, pgp_fingerprint, network)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, '{}')", record.network());
+        let insert_reg_record = format!("
+            INSERT INTO registration(wallet_id, discord, twitter, matrix, email, display_name, github, legal, web, pgp_fingerprint, network)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, '{}') 
+            ON CONFLICT (wallet_id, network) DO UPDATE SET 
+                discord = EXCLUDED.discord,
+                twitter = EXCLUDED.twitter,
+                matrix = EXCLUDED.matrix,
+                email = EXCLUDED.email,
+                display_name = EXCLUDED.display_name,
+                github = EXCLUDED.github,
+                legal = EXCLUDED.legal,
+                web = EXCLUDED.web,
+                pgp_fingerprint = EXCLUDED.pgp_fingerprint",
+            record.network());
+
         info!(query=?insert_reg_record,"QUERY");
         info!(record = ?record);
 


### PR DESCRIPTION
# What it is
Index/archive old registrations in the postgres DB.

# How it works
Iterate over old chain blocks, starting from block 0 to index old registrations in postgres DB, the state of the indexer (current blocks number and hash) is also saved in db to prevent re-iterating each time we start the registrar backend.

# Possible draw backs
Registration is saved only on `JudgementGiven` chain events. https://github.com/rotkonetworks/w3registrar/blob/93bd53008c5a1e8a9c7a53e4422dd390adda9a9b/src/indexer.rs#L59-L70