### PR TITLE
chor(test): add more tests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2415,3 +2415,83 @@ pub async fn spawn_http_serv() -> anyhow::Result<()> {
     axum::serve(listener, app).await.unwrap();
     Ok(())
 }
+
+mod unit_test {
+    use serde_json::to_string_pretty;
+
+    use crate::api::VersionedMessage;
+
+    #[tokio::test]
+    async fn se_de_ws_request() {
+        let wallet_id: String = String::from("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty");
+        let ws_msg = to_string_pretty(&serde_json::json!({
+            "version": "1.0",
+            "type": "SubscribeAccountState",
+            "payload": {
+                "network": "paseo",
+                "account": wallet_id,
+            },
+        }))
+        .unwrap();
+
+        assert_eq!(
+            true,
+            serde_json::from_str::<VersionedMessage>(&ws_msg).is_ok()
+        );
+
+        let ws_msg = to_string_pretty(&serde_json::json!({
+            "version": "1.0",
+            "type": "VerifyPGPKey",
+            "payload": {
+                "network": "paseo",
+                "account": wallet_id,
+                "pubkey": "asdf",
+                "signed_challenge": "asdf",
+            },
+        }))
+        .unwrap();
+
+        assert_eq!(
+            true,
+            serde_json::from_str::<VersionedMessage>(&ws_msg).is_ok()
+        );
+
+        let ws_msg = to_string_pretty(&serde_json::json!({
+          "version": "1.0",
+          "type": "SearchRegistration",
+          "payload": {
+              "network": "kusama",
+              "outputs": ["WalletID", "Discord", "Timeline"],
+              "filters": {
+                  "fields": [
+                      { "field": { "AccountId32": wallet_id }, "strict": false},
+                  ],
+                  "result_size": 3,
+              }
+          }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            true,
+            serde_json::from_str::<VersionedMessage>(&ws_msg).is_ok()
+        );
+
+        let ws_msg = to_string_pretty(&serde_json::json!({
+          "version": "1.0",
+          "type": "SearchRegistration",
+          "payload": {
+              "outputs": [],
+              "filters": {
+                  "fields": [],
+              }
+          }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            true,
+            serde_json::from_str::<VersionedMessage>(&ws_msg).is_ok()
+        );
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -329,6 +329,75 @@ mod tests {
     use tracing::{info, warn};
 
     static INIT: Once = Once::new();
+    fn init_tracing() {
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_test_writer()
+            .init();
+    }
+
+    #[tokio::test]
+    async fn supported_fields() {
+        init_config().await;
+        init_tracing();
+
+        let reg_index = 1;
+        let network = Network::Paseo;
+        let account =
+            AccountId32::from_str("1Qrotkokp6taAeLThuwgzR7Mu3YQonZohwrzixwGnrD1QDT").unwrap();
+        let identity = IdentityInfo {
+            legal: runtime_types::pallet_identity::types::Data::None,
+            image: runtime_types::pallet_identity::types::Data::None,
+            web: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            email: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            matrix: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            github: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            display: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            twitter: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            discord: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            pgp_fingerprint: Some([1; 20]),
+        };
+
+        let res = filter_accounts(&identity, &account, reg_index, &network).await;
+
+        assert_eq!(res.is_ok(), true);
+        assert_eq!(res.unwrap().keys().len(), 8);
+
+        let identity = IdentityInfo {
+            legal: runtime_types::pallet_identity::types::Data::Raw1([0]),
+            image: runtime_types::pallet_identity::types::Data::None,
+            web: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            email: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            matrix: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            github: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            display: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            twitter: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            discord: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            pgp_fingerprint: Some([1; 20]),
+        };
+
+        let res = filter_accounts(&identity, &account, reg_index, &network).await;
+
+        assert_eq!(res.is_ok(), false);
+
+        let identity = IdentityInfo {
+            legal: runtime_types::pallet_identity::types::Data::None,
+            image: runtime_types::pallet_identity::types::Data::Raw1([0]),
+            web: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            email: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            matrix: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            github: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            display: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            twitter: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            discord: runtime_types::pallet_identity::types::Data::Raw1([1]),
+            pgp_fingerprint: Some([1; 20]),
+        };
+
+        let res = filter_accounts(&identity, &account, reg_index, &network).await;
+
+        // NOTE: This test does not pass since we don't consider image as an variant in [Account]
+        assert_eq!(res.is_ok(), false);
+    }
 
     async fn init_config() {
         INIT.call_once(|| {
@@ -343,13 +412,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_provide_judgement_via_proxy() -> anyhow::Result<()> {
-        tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::DEBUG)
-            .with_test_writer()
-            .init();
-
-        info!("Starting judgment test");
         init_config().await;
+        init_tracing();
+        info!("Starting judgment test");
 
         let target_account =
             AccountId32::from_str("1Qrotkokp6taAeLThuwgzR7Mu3YQonZohwrzixwGnrD1QDT")?;


### PR DESCRIPTION
Test subjects now include:
- Supported fields: What fields to support in a registration request (IdentityInfo).
- WS request structure: Different ws request types (SubscribeAccountState, VerifyPGPKey, SearchRegistration) and allowed optional fields.