### PR TITLE
Review Postgres SQL queries

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -827,7 +827,8 @@ impl Query for RegistrationQuery {
                         ));
                     } else {
                         statement.push_str(&format!(
-                            "{} LIKE ${}",
+                            "{} ILIKE ${}", // Postgres uses ILIKE for case-insensitive matching, 
+                            //  LIKE is case-sensitive.
                             filter.field.table_column_name(),
                             index + 1
                         ));

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -858,7 +858,11 @@ impl Query for RegistrationQuery {
         let mut params = vec![];
         if let Some(condition) = &self.condition {
             for filter in condition.filters.iter() {
-                params.push(format!("{}", filter.field.inner()));
+                params.push(format!("{}", if filter.strict {
+                    filter.field.inner()    // exact match, e.g. display_name = 'Jow'
+                } else {
+                    format!("%{}%", filter.field.inner())   // e.g. display_name ILIKE '%Jow%'
+                }));
             }
         }
 


### PR DESCRIPTION
This pull request updates the `RegistrationQuery` implementation in `src/postgres.rs` to improve case-insensitive search behavior and parameter formatting for queries. The most important changes are:

**Query behavior improvements:**

* Changed the SQL operator from `LIKE` to `ILIKE` for case-insensitive matching in Postgres, ensuring that searches are not case-sensitive.

**Parameter formatting:**

* Updated how query parameters are constructed: now, if a filter is not strict, the parameter is wrapped with `%` wildcards for partial matches (e.g., `ILIKE '%Jow%'`); strict filters continue to use exact matching.